### PR TITLE
Arbitrary-session resume, realpath-normalized workspace grouping, and attach_session + orphan reattachment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,474 +1,681 @@
-import { z } from "zod";
-import { createUserMessage } from "@deepseek-ai/dsh-llm";
-import { SessionId } from "@deepseek-ai/dsh-session";
-import "@deepseek-ai/cordis";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { randomUUID } from "node:crypto";
-import http from "node:http";
-import { resolve } from "node:path";
-//#region ../../core/scope/src/index.ts
+/**
+ * dsh-harness-mcp-server — 在 Harness 内部启动 MCP server, 暴露 Harness 能力给 Hermes(大脑)。
+ *
+ * 工具集:
+ *   - echo                : 验证 MCP server 连通
+ *   - harness_list_tools  : 列出 Harness 工具注册表
+ *   - agent_run           : 同步执行任务(改代码/分析/跑命令), 返回结构化结果
+ *   - task_inbox          : Hermes push 结构化任务(任务+记忆上下文)到 Harness 队列, 异步执行, 返回 taskId
+ *   - task_result         : 取回任务的结构化结果(changes/verification/leftovers)
+ *   - attach_session      : 把会话归组到其 cwd 对应的工作区(手动补给站)
+ *   - rename_session      : 给已有会话改名
+ *
+ * sessionId 续接: 指定 sessionId 时按 本进程池 → live 会话(UI 手开)→ 持久化 resume 三级接管,
+ * 前两者都找不到才报错, 所以进程重启前/UI 手开的会话也能续接。
+ * 工作区分组: cwd 先 realpath 规范化再 `workspaceRegistry.resolveByPath ?? create` + attachSession;
+ * 启动时对存量未分组会话补挂一次(存量捞回)。
+ *
+ * 回路: Hermes 记忆 →(context)→ task_inbox → Harness agent 执行 → 结果进队列 → task_result → Hermes 持久化
+ */
+import { z } from 'zod';
+import { createUserMessage } from '@deepseek-ai/dsh-llm';
+import { SessionId } from '@deepseek-ai/dsh-session';
+//#region core/scope (inlined, same as upstream tsdown bundle)
 /** Context tag written by {@link createScope}. */
 const kScope = Symbol("dsh.scope");
 /**
-* Read the nearest scope tag inherited by a context.
-* @param ctx - context to inspect.
-* @returns its scope key, or `undefined` for an unscoped context.
-*/
+ * Read the nearest scope tag inherited by a context.
+ * @param ctx - context to inspect.
+ * @returns its scope key, or `undefined` for an unscoped context.
+ */
 function scopeOf(ctx) {
 	return ctx[kScope];
 }
 //#endregion
-//#region lib/types/index.js
-/**
-* dsh-harness-mcp-server — 在 Harness 内部启动 MCP server, 暴露 Harness 能力给 Hermes(大脑)。
-*
-* 工具集:
-*   - echo                : 验证 MCP server 连通
-*   - harness_list_tools  : 列出 Harness 工具注册表
-*   - agent_run           : 同步执行任务(改代码/分析/跑命令), 返回结构化结果
-*   - task_inbox          : Hermes push 结构化任务(任务+记忆上下文)到 Harness 队列, 异步执行, 返回 taskId
-*   - task_result         : 取回任务的结构化结果(changes/verification/leftovers)
-*
-* 回路: Hermes 记忆 →(context)→ task_inbox → Harness agent 执行 → 结果进队列 → task_result → Hermes 持久化
-*/
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { randomUUID } from 'node:crypto';
+import { realpath } from 'node:fs/promises';
+import http from 'node:http';
+import { resolve } from 'node:path';
 /** Cordis 插件名 */
-const name = "harness-mcp-server";
-/** 声明依赖的核心服务 */
-const inject = [
-	"tools",
-	"llm",
-	"agents",
-	"agentPresets"
-];
+export const name = 'harness-mcp-server';
+/**
+ * 声明依赖的核心服务。
+ * workspaceRegistry/sessionPersistence/sessions 是续接/归组三个增量用到的服务——
+ * 漏声明会在真实启动时拿不到服务(本插件曾经踩过, 务必与代码里的 ctx.get 对齐)。
+ */
+export const inject = ['tools', 'llm', 'agents', 'agentPresets', 'workspaceRegistry', 'sessionPersistence', 'sessions'];
 /** 运行时配置(apply 时从 config 初始化, 提供安全默认值) */
 const runtimeConfig = {
-	provider: "deepseek-official",
-	model: "",
-	preset: "standard",
-	maxQueue: 100,
-	taskTtlMs: 600 * 1e3,
-	maxAgents: 8,
-	authToken: "",
-	workspaceRoots: []
+    provider: 'deepseek-official',
+    // 空字符串 = 不覆盖 model, 跟随 dsh 的用户/默认设置; 显式配置则覆盖
+    model: '',
+    preset: 'standard',
+    maxQueue: 100,
+    taskTtlMs: 10 * 60 * 1000,
+    maxAgents: 8,
+    authToken: '',
+    workspaceRoots: [],
 };
 /** 工具回调统一返回 MCP text content */
 function out(content) {
-	return { content: [{
-		type: "text",
-		text: content
-	}] };
+    return { content: [{ type: 'text', text: content }] };
+}
+/**
+ * cwd realpath 规范化: 解析符号链接与 .. 段, 使 cwd 能与 workspace.path(存储时为 realpath 规范化值)
+ * 精确比对——这是官方 attachSession 强校验通过的前提。目录不存在时回退 resolve 结果, 由调用方告警不阻断。
+ */
+async function canonicalCwd(raw) {
+    try {
+        return await realpath(raw);
+    }
+    catch {
+        return resolve(raw);
+    }
+}
+/** 官方 session.create RPC 同款姿势: resolveByPath ?? create, 幂等; 无 workspaceRegistry 时返回 undefined */
+async function ensureWorkspace(ctx, canonical) {
+    const registry = ctx.get('workspaceRegistry');
+    if (!registry)
+        return undefined;
+    return (await registry.resolveByPath?.(canonical)) ?? (await registry.create?.(canonical));
+}
+/** 把会话挂名到其 cwd 对应的工作区。attachSession 内部强校验 realpath(header.cwd) 精确等于 workspace.path,
+ *  所以 canonical 必须是 header.cwd 的 realpath 规范化值。失败告警不阻断任务(分组是锦上添花)。 */
+async function attachToWorkspace(ctx, canonical, sessionId) {
+    try {
+        const ws = await ensureWorkspace(ctx, canonical);
+        if (ws?.attachSession)
+            await ws.attachSession(sessionId);
+    }
+    catch (e) {
+        console.warn('[harness-mcp-server] workspace attach failed:', e?.message ?? e);
+    }
+}
+/** 按会话 header 的 cwd(realpath 规范化后)补挂工作区; header 无 cwd 时静默跳过 */
+async function attachSessionCwd(ctx, sessionId, cwd) {
+    if (cwd === undefined)
+        return;
+    await attachToWorkspace(ctx, await canonicalCwd(cwd), sessionId);
 }
 /** 常驻 agent 会话(按 cwd 复用, 省 token: 避免每次全量加载项目上下文) */
-const liveAgents = /* @__PURE__ */ new Map();
+const liveAgents = new Map();
 /** sessionId → cwd 索引(支持按 session 续接: 指定 sessionId 时定位到对应 cwd 的常驻会话) */
-const sessionToCwd = /* @__PURE__ */ new Map();
+const sessionToCwd = new Map();
 /** 每个 cwd 的串行执行锁(防同一 agent 会话被并发 followup 冲突) */
-const agentLocks = /* @__PURE__ */ new Map();
-/** 获取(或创建)指定 cwd 的常驻 agent 会话; 传 sessionId 时续接指定会话; 传 title 时给新会话命名 */
+const agentLocks = new Map();
+/** 获取(或创建)指定 cwd 的常驻 agent 会话; 传 sessionId 时接管指定会话; 传 title 时给新会话命名 */
 async function getAgent(ctx, cwd, sessionId, title) {
-	if (sessionId) {
-		const targetCwd = sessionToCwd.get(sessionId);
-		if (targetCwd !== void 0) {
-			const existing = liveAgents.get(targetCwd);
-			if (existing) {
-				liveAgents.delete(targetCwd);
-				liveAgents.set(targetCwd, existing);
-				return existing;
-			}
-		}
-		throw new Error(`session not found for resume: ${sessionId} (evicted by LRU or process restarted)`);
-	}
-	const existing = liveAgents.get(cwd);
-	if (existing) {
-		liveAgents.delete(cwd);
-		liveAgents.set(cwd, existing);
-		return existing;
-	}
-	while (liveAgents.size >= runtimeConfig.maxAgents) {
-		const oldestKey = liveAgents.keys().next().value;
-		if (oldestKey === void 0) break;
-		const old = liveAgents.get(oldestKey);
-		liveAgents.delete(oldestKey);
-		if (old) {
-			sessionToCwd.delete(String(old.sessionId));
-			try {
-				old.handle?.dispose?.();
-			} catch {}
-		}
-	}
-	const newSessionId = SessionId(randomUUID());
-	const handle = await ctx.agents.create({
-		sessionId: newSessionId,
-		meta: {
-			cwd,
-			agentPreset: runtimeConfig.preset
-		},
-		agentOptions: {
-			provider: runtimeConfig.provider,
-			...runtimeConfig.model ? { model: runtimeConfig.model } : {}
-		},
-		setup: async (agentCtx) => {
-			if (scopeOf(agentCtx) === void 0) {
-				console.warn("[harness-mcp-server] agent ctx unscoped (dsh rc.6 bug); preset mount skipped — upgrade dsh for full tool support");
-				return;
-			}
-			await ctx.agentPresets.mount(agentCtx, runtimeConfig.preset);
-		}
-	});
-	const rec = {
-		sessionId: newSessionId,
-		handle
-	};
-	liveAgents.set(cwd, rec);
-	sessionToCwd.set(String(newSessionId), cwd);
-	(async () => {
-		try {
-			const registry = ctx.get("workspaceRegistry");
-			if (registry?.create) await (await registry.create(cwd)).attachSession?.(newSessionId);
-		} catch (e) {
-			console.warn("[harness-mcp-server] workspace attach failed:", String(e));
-		}
-	})();
-	if (title) try {
-		const session = handle.agent.session;
-		ctx.get("sessionTitle")?.rename?.(session, title);
-	} catch (e) {
-		console.warn("[harness-mcp-server] session title set failed:", String(e));
-	}
-	return rec;
+    // 指定 sessionId: 接管已有会话(长任务分多轮投喂 / 中断后恢复 / UI 手开的会话)
+    if (sessionId) {
+        // 先看本进程常驻池(指定 sessionId 时定位到对应 cwd 的常驻会话; 命中 LRU 移到末尾, 保留上游语义)
+        const targetCwd = sessionToCwd.get(sessionId);
+        if (targetCwd !== undefined) {
+            const existing = liveAgents.get(targetCwd);
+            if (existing) {
+                liveAgents.delete(targetCwd);
+                liveAgents.set(targetCwd, existing);
+                return existing;
+            }
+        }
+        const sid = SessionId(sessionId);
+        // 不在常驻池: 看 live(UI 手开的、别的插件持有的会话), 直接接管、不持有 dispose(归其 owner)
+        const live = ctx.agents.get(sid);
+        if (live) {
+            // live 会话也补挂工作区(幂等): 用户手开的会话若尚未归组, 这里一并挂名
+            await attachSessionCwd(ctx, sid, live.session.header.cwd);
+            // no-op dispose 兜底: executeTask 只在 disposeAfter 为 true 时调用 dispose
+            return { sessionId: sid, handle: { agent: live, dispose: () => Promise.resolve() }, disposeAfter: false };
+        }
+        // live 也没有: 从持久化会话存储 resume 并接管(进程重启前的会话、LRU 淘汰后被释放的会话)
+        let handle;
+        try {
+            handle = await ctx.agents.resume({
+                resumeSessionId: sid,
+                agentOptions: {
+                    provider: runtimeConfig.provider,
+                    // model 为空则省略, 让 dsh 跟随用户/默认设置; 显式配置则覆盖
+                    ...(runtimeConfig.model ? { model: runtimeConfig.model } : {}),
+                },
+                setup: async (agentCtx) => {
+                    // 同 create 路径: dsh rc.6 agent ctx 可能丢 scope tag, 检测不到就跳过挂载(降级为无工具 agent)
+                    if (scopeOf(agentCtx) === undefined) {
+                        console.warn('[harness-mcp-server] agent ctx unscoped (dsh rc.6 bug); preset mount skipped — upgrade dsh for full tool support');
+                        return;
+                    }
+                    await ctx.agentPresets.mount(agentCtx, runtimeConfig.preset);
+                },
+            });
+        }
+        catch (e) {
+            // 恢复失败返回明确错误(沿用上游错误风格): 不在常驻池、不是 live、持久化里也没有(或 resume 失败)
+            throw new Error(`session not found for resume: ${sessionId} (not live and not persisted; ${e?.message ?? e})`);
+        }
+        await attachSessionCwd(ctx, sid, handle.agent.session.header.cwd);
+        return { sessionId: sid, handle, disposeAfter: true };
+    }
+    const existing = liveAgents.get(cwd);
+    if (existing) {
+        // LRU: 命中则移到末尾(最近使用)
+        liveAgents.delete(cwd);
+        liveAgents.set(cwd, existing);
+        // 自愈: 幂等补挂(已在花名册则 no-op; 首次挂名失败的池会话在此被捞回)
+        await attachToWorkspace(ctx, await canonicalCwd(cwd), existing.sessionId);
+        return existing;
+    }
+    // LRU 淘汰: 超过上限时逐出最久未用的会话
+    while (liveAgents.size >= runtimeConfig.maxAgents) {
+        const oldestKey = liveAgents.keys().next().value;
+        if (oldestKey === undefined)
+            break;
+        const old = liveAgents.get(oldestKey);
+        liveAgents.delete(oldestKey);
+        if (old) {
+            sessionToCwd.delete(String(old.sessionId));
+            try {
+                old.handle?.dispose?.();
+            }
+            catch { /* 忽略 */ }
+        }
+    }
+    const newSessionId = SessionId(randomUUID());
+    // cwd 先 realpath 规范化: session header 的 cwd 与 workspace.path 必须精确相等,
+    // 否则 attachSession 强校验 reject(只会 create 注册而 UI 仍落未分组)
+    const canonical = await canonicalCwd(cwd);
+    const handle = await ctx.agents.create({
+        sessionId: newSessionId,
+        // 声明 preset: 为未来 Harness 版本消费 meta.agentPreset 做准备; 当前版本靠 setup 里手动 mount 兜底。
+        meta: { cwd: canonical, agentPreset: runtimeConfig.preset },
+        agentOptions: {
+            provider: runtimeConfig.provider,
+            // model 为空则省略, 让 dsh 跟随用户/默认设置; 显式配置则覆盖
+            ...(runtimeConfig.model ? { model: runtimeConfig.model } : {}),
+        },
+        setup: async (agentCtx) => {
+            // 关键: 通过 setup 挂载 preset(含 bash/fs/todo/web 等完整工具)。
+            // dsh rc.6 的 agent-loop 有 bug: setup 收到的 agent ctx 丢失 scope tag,
+            // 导致 mount 抛 'refusing to compose an unscoped context'。
+            // 这里检测 scope, 无 scope 时跳过挂载(降级为无工具 agent), 避免 agent_run 整体崩溃。
+            // master 及后续版本已修复, 会正常走 mount。
+            if (scopeOf(agentCtx) === undefined) {
+                console.warn('[harness-mcp-server] agent ctx unscoped (dsh rc.6 bug); preset mount skipped — upgrade dsh for full tool support');
+                return;
+            }
+            await ctx.agentPresets.mount(agentCtx, runtimeConfig.preset);
+        },
+    });
+    const rec = { sessionId: newSessionId, handle };
+    liveAgents.set(cwd, rec);
+    sessionToCwd.set(String(newSessionId), cwd);
+    // 分组: 把会话归属到 cwd 对应的工作区(resolveByPath ?? create + attachSession; 可选依赖; headless 环境自动跳过)
+    void (async () => {
+        try {
+            const ws = await ensureWorkspace(ctx, canonical);
+            if (ws?.attachSession)
+                await ws.attachSession(newSessionId);
+        }
+        catch (e) {
+            console.warn('[harness-mcp-server] workspace attach failed:', String(e));
+        }
+    })();
+    // title 命名(可选): 创建会话后立即命名(走 sessionTitle 服务的 rename)
+    if (title) {
+        try {
+            const session = handle.agent.session;
+            const st = ctx.get('sessionTitle');
+            st?.rename?.(session, title);
+        }
+        catch (e) {
+            console.warn('[harness-mcp-server] session title set failed:', String(e));
+        }
+    }
+    return rec;
 }
 /** 同一 cwd 串行执行, 避免并发 followup 同一会话 */
 async function withLock(cwd, fn) {
-	const next = (agentLocks.get(cwd) ?? Promise.resolve()).then(fn, fn);
-	agentLocks.set(cwd, next.catch(() => {}));
-	return next;
+    const prev = agentLocks.get(cwd) ?? Promise.resolve();
+    const next = prev.then(fn, fn);
+    agentLocks.set(cwd, next.catch(() => { }));
+    return next;
 }
 /** 从 agent 最终回答里解析 changes/verification/leftovers(从后往前找候选, 更可靠) */
 function parseSummary(assistantText) {
-	const empty = {
-		changes: "",
-		verification: "",
-		leftovers: ""
-	};
-	const candidates = [];
-	const re = /\{[\s\S]*?\}/g;
-	let m;
-	while ((m = re.exec(assistantText)) !== null) candidates.push(m[0]);
-	for (let i = candidates.length - 1; i >= 0; i--) try {
-		const obj = JSON.parse(candidates[i]);
-		const s = (v) => typeof v === "string" ? v : "";
-		const changes = s(obj.changes) || s(obj.改动);
-		const verification = s(obj.verification) || s(obj.验证);
-		const leftovers = s(obj.leftovers) || s(obj.遗留) || s(obj.leftover);
-		if (changes || verification || leftovers) return {
-			changes,
-			verification,
-			leftovers
-		};
-	} catch {}
-	return empty;
+    const empty = { changes: '', verification: '', leftovers: '' };
+    // 收集所有 {...} 候选(agent 被要求输出一行 summary JSON)
+    const candidates = [];
+    const re = /\{[\s\S]*?\}/g;
+    let m;
+    while ((m = re.exec(assistantText)) !== null) {
+        candidates.push(m[0]);
+    }
+    // 从后往前: 最后出现的候选最可能是最终 summary, 逐个尝试解析
+    for (let i = candidates.length - 1; i >= 0; i--) {
+        try {
+            const obj = JSON.parse(candidates[i]);
+            const s = (v) => (typeof v === 'string' ? v : '');
+            const changes = s(obj.changes) || s(obj.改动);
+            const verification = s(obj.verification) || s(obj.验证);
+            const leftovers = s(obj.leftovers) || s(obj.遗留) || s(obj.leftover);
+            // 只要含任一 summary 字段就采纳, 否则继续尝试更早的候选
+            if (changes || verification || leftovers) {
+                return { changes, verification, leftovers };
+            }
+        }
+        catch {
+            // 非合法 JSON, 继续尝试下一个候选
+        }
+    }
+    return empty;
 }
 /** 分字段限长, 保证返回的永远是完整合法 JSON(避免 slice(-16000) 截断开头导致非法 JSON) */
 function truncateResult(result) {
-	return {
-		...result,
-		assistantText: result.assistantText.slice(0, 8e3),
-		toolCalls: result.toolCalls.slice(0, 50).map((c) => ({
-			...c,
-			args: c.args.slice(0, 2e3)
-		})),
-		toolResults: result.toolResults.slice(0, 20).map((r) => r.slice(0, 2e3))
-	};
+    return {
+        ...result,
+        assistantText: result.assistantText.slice(0, 8000),
+        toolCalls: result.toolCalls.slice(0, 50).map((c) => ({ ...c, args: c.args.slice(0, 2000) })),
+        toolResults: result.toolResults.slice(0, 20).map((r) => r.slice(0, 2000)),
+    };
 }
 /** 核心执行: 组装任务(注入记忆上下文+结构化要求) → agent 执行 → 读结构化结果 */
 async function executeTask(ctx, task, context, cwd, resumeSessionId, title) {
-	const workdir = cwd ? resolve(cwd) : process.cwd();
-	if (runtimeConfig.workspaceRoots.length > 0) {
-		if (!runtimeConfig.workspaceRoots.some((root) => {
-			const r = resolve(root);
-			return workdir === r || workdir.startsWith(r + "/");
-		})) throw new Error(`cwd not allowed (outside workspaceRoots): ${workdir}`);
-	}
-	return withLock(workdir, async () => {
-		const { sessionId, handle } = await getAgent(ctx, workdir, resumeSessionId, title);
-		const baseline = (handle.agent.session.log ?? []).length;
-		const fullTask = [
-			context ? `【记忆/上下文(供参考, 来自 Hermes 大脑)】\n${context}\n` : "",
-			`【任务】\n${task}\n`,
-			`【完成后必须】用一行 JSON 总结(不要 markdown 代码块包裹, 直接输出这一行):`,
-			`{"changes":"改了什么","verification":"怎么验证的","leftovers":"遗留问题"}`
-		].filter(Boolean).join("\n");
-		handle.agent.followup(createUserMessage({
-			content: [{
-				type: "text",
-				text: fullTask
-			}],
-			source: {
-				kind: "plugin",
-				plugin: "harness-mcp-server"
-			}
-		}));
-		await handle.agent.whenIdle();
-		const result = {
-			taskId: "",
-			sessionId,
-			assistantText: "",
-			toolCalls: [],
-			toolResults: [],
-			changes: "",
-			verification: "",
-			leftovers: ""
-		};
-		try {
-			const log = (handle.agent.session.log ?? []).slice(baseline);
-			const extractText = (obj, out) => {
-				if (Array.isArray(obj)) {
-					obj.forEach((x) => extractText(x, out));
-					return;
-				}
-				if (obj && typeof obj === "object") {
-					const rec = obj;
-					if (typeof rec.text === "string" && rec.text.trim()) out.push(rec.text);
-					if (typeof rec.content === "string" && rec.content.trim()) out.push(rec.content);
-					for (const v of Object.values(rec)) extractText(v, out);
-				}
-			};
-			for (const e of log) {
-				const ev = e;
-				if (ev.type === "assistant/message") {
-					const content = ev.data?.message?.content;
-					if (content) {
-						const texts = content.filter((c) => c.type === "text" && c.text).map((c) => c.text);
-						if (texts.length) result.assistantText += texts.join("\n") + "\n";
-					}
-				} else if (ev.type === "tool/call") {
-					const d = ev.data;
-					result.toolCalls.push({
-						name: d?.name ?? "?",
-						args: (d?.arguments ?? JSON.stringify(d?.input ?? null) ?? "").slice(0, 2e3)
-					});
-				} else if (ev.type === "tool/result") {
-					const texts = [];
-					extractText(ev.data ?? ev, texts);
-					if (texts.length) result.toolResults.push(texts.join("\n").slice(0, 3e3));
-				}
-			}
-		} catch (e) {
-			result.assistantText = `[读输出异常] ${String(e)}`;
-		}
-		const summary = parseSummary(result.assistantText);
-		result.changes = summary.changes;
-		result.verification = summary.verification;
-		result.leftovers = summary.leftovers;
-		return result;
-	});
+    // 规范化 cwd: realpath 解析符号链接与 .. 段, 避免 /a、/a/.、相对路径、符号链接成为不同 Map key
+    // 导致重复创建会话/并发冲突; 同时也是与 workspace.path 精确比对的唯一 canon
+    const workdir = await canonicalCwd(cwd ? resolve(cwd) : process.cwd());
+    // cwd 白名单: 配置了 workspaceRoots 时, 只允许在列出的目录下干活(防路径穿越)
+    if (runtimeConfig.workspaceRoots.length > 0) {
+        const allowed = runtimeConfig.workspaceRoots.some((root) => {
+            const r = resolve(root);
+            return workdir === r || workdir.startsWith(r + '/');
+        });
+        if (!allowed) {
+            throw new Error(`cwd not allowed (outside workspaceRoots): ${workdir}`);
+        }
+    }
+    // sessionId 用 session 锁, 否则用 cwd 锁——都防同一 agent 会话被并发 followup
+    const lockKey = resumeSessionId ? `session:${resumeSessionId}` : workdir;
+    return withLock(lockKey, async () => {
+        const { sessionId, handle, disposeAfter } = await getAgent(ctx, workdir, resumeSessionId, title);
+        const baseline = (handle.agent.session.log ?? []).length;
+        // 组装完整任务文本: 记忆上下文 + 任务 + 结构化输出要求
+        const fullTask = [
+            context ? `【记忆/上下文(供参考, 来自 Hermes 大脑)】\n${context}\n` : '',
+            `【任务】\n${task}\n`,
+            `【完成后必须】用一行 JSON 总结(不要 markdown 代码块包裹, 直接输出这一行):`,
+            `{"changes":"改了什么","verification":"怎么验证的","leftovers":"遗留问题"}`,
+        ].filter(Boolean).join('\n');
+        handle.agent.followup(createUserMessage({ content: [{ type: 'text', text: fullTask }], source: { kind: 'plugin', plugin: 'harness-mcp-server' } }));
+        await handle.agent.whenIdle();
+        // 结构化读输出
+        const result = {
+            taskId: '', sessionId, assistantText: '', toolCalls: [], toolResults: [],
+            changes: '', verification: '', leftovers: '',
+        };
+        try {
+            const log = (handle.agent.session.log ?? []).slice(baseline);
+            const extractText = (obj, out) => {
+                if (Array.isArray(obj)) {
+                    obj.forEach((x) => extractText(x, out));
+                    return;
+                }
+                if (obj && typeof obj === 'object') {
+                    const rec = obj;
+                    if (typeof rec.text === 'string' && rec.text.trim())
+                        out.push(rec.text);
+                    if (typeof rec.content === 'string' && rec.content.trim())
+                        out.push(rec.content);
+                    for (const v of Object.values(rec))
+                        extractText(v, out);
+                }
+            };
+            for (const e of log) {
+                const ev = e;
+                if (ev.type === 'assistant/message') {
+                    const d = ev.data;
+                    const content = d?.message?.content;
+                    if (content) {
+                        const texts = content.filter((c) => c.type === 'text' && c.text).map((c) => c.text);
+                        if (texts.length)
+                            result.assistantText += texts.join('\n') + '\n';
+                    }
+                }
+                else if (ev.type === 'tool/call') {
+                    const d = ev.data;
+                    result.toolCalls.push({
+                        name: d?.name ?? '?',
+                        args: (d?.arguments ?? JSON.stringify(d?.input ?? null) ?? '').slice(0, 2000),
+                    });
+                }
+                else if (ev.type === 'tool/result') {
+                    const texts = [];
+                    extractText(ev.data ?? ev, texts);
+                    if (texts.length)
+                        result.toolResults.push(texts.join('\n').slice(0, 3000));
+                }
+            }
+        }
+        catch (e) {
+            result.assistantText = `[读输出异常] ${String(e)}`;
+        }
+        // 解析结构化 summary
+        const summary = parseSummary(result.assistantText);
+        result.changes = summary.changes;
+        result.verification = summary.verification;
+        result.leftovers = summary.leftovers;
+        // resume 兜底分支: 尽力 flush 持久化, 再释放我们 resume 出来的句柄(不留给僵尸 live agent)
+        if (disposeAfter) {
+            try {
+                await ctx.get('sessions')?.flush?.(handle.agent.session);
+            }
+            catch {
+                /* flush 失败不阻断结果返回 */
+            }
+            try {
+                await handle.dispose();
+            }
+            catch {
+                /* 释放失败不影响结果 */
+            }
+        }
+        return result;
+    });
 }
-const taskQueue = /* @__PURE__ */ new Map();
-/** 在给定 McpServer 上注册工具 */
-function registerTools(mcp, ctx) {
-	mcp.tool("echo", "回显输入, 验证 MCP server 连通", { text: z.string() }, async ({ text }) => {
-		return out(`收到: ${text} @ ${Date.now()}`);
-	});
-	mcp.tool("harness_list_tools", "列出 Harness 当前注册的所有工具名", {}, async () => {
-		const tools = ctx.tools;
-		const names = tools && typeof tools.keys === "function" ? Array.from(tools.keys()) : [];
-		return out(JSON.stringify(names));
-	});
-	mcp.tool("agent_run", "同步执行任务(改代码/分析/跑命令), 返回结构化结果。可传 sessionId 续接已有会话(长任务分多轮投喂)。", {
-		task: z.string().describe("要 Harness 执行的自然语言任务"),
-		context: z.string().optional().describe("Hermes 记忆/上下文, 注入给 agent 参考"),
-		cwd: z.string().optional().describe("工作目录(默认当前)"),
-		sessionId: z.string().optional().describe("续接已有会话的 sessionId(来自上次 agent_run 结果里的 sessionId 字段)"),
-		title: z.string().optional().describe("新会话的标题(创建时命名, 便于会话列表归档)")
-	}, async ({ task, context, cwd, sessionId, title }) => {
-		const result = await executeTask(ctx, task, context ?? "", cwd ?? process.cwd(), sessionId, title);
-		return out(JSON.stringify(truncateResult(result), null, 2));
-	});
-	mcp.tool("task_inbox", "Hermes 把结构化任务(任务+记忆上下文)推入 Harness 队列, 异步执行, 返回 taskId。记忆喂编码的入口。", {
-		task: z.string().describe("任务内容"),
-		context: z.string().optional().describe("Hermes 记忆/上下文, 随任务注入给 agent"),
-		cwd: z.string().optional().describe("工作目录"),
-		sessionId: z.string().optional().describe("续接已有会话的 sessionId(来自上次 agent_run 结果)"),
-		title: z.string().optional().describe("新会话的标题(创建时命名)")
-	}, async ({ task, context, cwd, sessionId, title }) => {
-		const now = Date.now();
-		for (const [tid, t] of taskQueue) if ((t.status === "done" || t.status === "error") && t.finishedAt && now - t.finishedAt > runtimeConfig.taskTtlMs) taskQueue.delete(tid);
-		let active = 0;
-		for (const t of taskQueue.values()) if (t.status === "queued" || t.status === "running") active++;
-		if (active >= runtimeConfig.maxQueue) return out(JSON.stringify({ error: `task queue full (${active}/${runtimeConfig.maxQueue})` }));
-		const id = randomUUID();
-		const item = {
-			id,
-			task,
-			context: context ?? "",
-			cwd: cwd ?? process.cwd(),
-			status: "queued",
-			createdAt: now,
-			...sessionId ? { sessionId } : {},
-			...title ? { title } : {}
-		};
-		taskQueue.set(id, item);
-		(async () => {
-			item.status = "running";
-			try {
-				item.result = await executeTask(ctx, item.task, item.context, item.cwd, item.sessionId, item.title);
-				item.result.taskId = id;
-				item.status = "done";
-			} catch (e) {
-				item.error = String(e);
-				item.status = "error";
-			}
-			item.finishedAt = Date.now();
-		})();
-		return out(JSON.stringify({
-			taskId: id,
-			status: "queued"
-		}));
-	});
-	mcp.tool("task_result", "取回 task_inbox 提交任务的结构化结果(changes/verification/leftovers)。", { taskId: z.string().describe("task_inbox 返回的 taskId") }, async ({ taskId }) => {
-		const item = taskQueue.get(taskId);
-		if (!item) return out(JSON.stringify({ error: `task not found: ${taskId}` }));
-		return out(JSON.stringify({
-			taskId: item.id,
-			status: item.status,
-			error: item.error,
-			result: item.result ? truncateResult(item.result) : void 0
-		}, null, 2));
-	});
-	mcp.tool("rename_session", "给已有会话改名(走 sessionTitle 服务的 rename), 便于会话列表归档区分。", {
-		sessionId: z.string().describe("要改名的会话 id(来自 agent_run 结果里的 sessionId 字段)"),
-		title: z.string().describe("新标题")
-	}, async ({ sessionId, title }) => {
-		try {
-			const session = ctx.get("sessions")?.get?.(sessionId);
-			if (!session) return out(JSON.stringify({ error: `session not found: ${sessionId}` }));
-			const st = ctx.get("sessionTitle");
-			if (!st?.rename) return out(JSON.stringify({ error: "sessionTitle service unavailable" }));
-			const snapshot = st.rename(session, title);
-			return out(JSON.stringify({
-				ok: true,
-				sessionId,
-				title: snapshot?.title ?? title
-			}));
-		} catch (e) {
-			return out(JSON.stringify({ error: String(e) }));
-		}
-	});
+const taskQueue = new Map();
+/** 找会话 header: live 优先, 其次持久化 list(轻量元数据扫描, 不加载整日志) */
+async function findSessionHeader(ctx, sessionId) {
+    const sessions = ctx.get('sessions');
+    const live = sessions?.get?.(sessionId);
+    if (live !== undefined)
+        return live.header;
+    const persistence = ctx.get('sessionPersistence');
+    for (const header of (await persistence?.list?.()) ?? []) {
+        if (header.id === sessionId)
+            return header;
+    }
+    return undefined;
 }
 /**
-* 插件入口: 启动 MCP server(StreamableHTTP, 跨网), 通过 ctx 桥接 Harness 能力。
-*/
-async function apply(ctx, config = {}) {
-	if (config.provider) runtimeConfig.provider = config.provider;
-	if (config.model) runtimeConfig.model = config.model;
-	if (config.preset) runtimeConfig.preset = config.preset;
-	if (config.maxQueue !== void 0) runtimeConfig.maxQueue = config.maxQueue;
-	if (config.taskTtlMs !== void 0) runtimeConfig.taskTtlMs = config.taskTtlMs;
-	if (config.maxAgents !== void 0) runtimeConfig.maxAgents = config.maxAgents;
-	if (config.authToken) runtimeConfig.authToken = config.authToken;
-	if (config.workspaceRoots) runtimeConfig.workspaceRoots = config.workspaceRoots;
-	const port = config.port ?? 8090;
-	const host = config.host ?? "127.0.0.1";
-	console.log("[harness-mcp-server] apply called, port=", port);
-	const servers = /* @__PURE__ */ new Map();
-	const transports = /* @__PURE__ */ new Map();
-	const server = http.createServer(async (req, res) => {
-		if (runtimeConfig.authToken) {
-			if (req.headers["authorization"] !== `Bearer ${runtimeConfig.authToken}`) {
-				res.writeHead(401, { "Content-Type": "application/json" });
-				res.end(JSON.stringify({
-					jsonrpc: "2.0",
-					error: {
-						code: -32001,
-						message: "Unauthorized"
-					},
-					id: null
-				}));
-				return;
-			}
-		}
-		const sessionId = req.headers["mcp-session-id"] ?? void 0;
-		const existing = sessionId ? transports.get(sessionId) : void 0;
-		if (existing) {
-			if (req.method === "GET" || req.method === "POST" || req.method === "DELETE") {
-				await existing.handleRequest(req, res);
-				return;
-			}
-			res.writeHead(405, { "Content-Type": "application/json" });
-			res.end(JSON.stringify({
-				jsonrpc: "2.0",
-				error: {
-					code: -32600,
-					message: "Method not allowed"
-				},
-				id: null
-			}));
-			return;
-		}
-		if (req.method === "POST" && !sessionId) {
-			const mcp = new McpServer({
-				name: "harness",
-				version: "0.1.9"
-			});
-			registerTools(mcp, ctx);
-			const transport = new StreamableHTTPServerTransport({
-				sessionIdGenerator: () => randomUUID(),
-				onsessioninitialized: (sid) => {
-					transports.set(sid, transport);
-					servers.set(sid, mcp);
-				}
-			});
-			transport.onclose = () => {
-				const sid = transport.sessionId;
-				if (sid) {
-					transports.delete(sid);
-					servers.delete(sid);
-				}
-			};
-			await mcp.connect(transport);
-			await transport.handleRequest(req, res);
-			return;
-		}
-		if (sessionId) {
-			res.writeHead(404, { "Content-Type": "application/json" });
-			res.end(JSON.stringify({
-				jsonrpc: "2.0",
-				error: {
-					code: -32001,
-					message: "Session not found"
-				},
-				id: null
-			}));
-			return;
-		}
-		res.writeHead(400, { "Content-Type": "application/json" });
-		res.end(JSON.stringify({
-			jsonrpc: "2.0",
-			error: {
-				code: -32600,
-				message: "Invalid request"
-			},
-			id: null
-		}));
-	});
-	server.listen(port, host, () => {
-		console.log(`[harness-mcp-server] MCP server listening on ${host}:${port}`);
-	});
-	server.on("error", (e) => {
-		console.error("[harness-mcp-server] HTTP server error:", e.message);
-	});
-	ctx.effect(() => {
-		return () => {
-			server.close();
-			transports.clear();
-			servers.clear();
-			liveAgents.clear();
-			sessionToCwd.clear();
-			agentLocks.clear();
-			taskQueue.clear();
-		};
-	}, "harness-mcp-server");
+ * 存量捞回: 启动时把现存未分组的会话补挂到已注册工作区。
+ * 条件: header.cwd 的 realpath 等于某已注册 workspace.path, 且该 sessionId 不在其花名册里。
+ * 只补挂到"已注册"工作区, 不新建(避免把无关目录刷成新工作区); 单会话失败不影响其余。
+ */
+async function reattachOrphanSessions(ctx) {
+    const registry = ctx.get('workspaceRegistry');
+    const byPath = new Map();
+    for (const ws of registry?.list?.() ?? [])
+        byPath.set(ws.path, ws);
+    if (byPath.size === 0)
+        return { attached: 0, failed: 0 };
+    // live + 持久化 header 合并(live 优先), 按 id 去重
+    const headers = new Map();
+    const sessions = ctx.get('sessions');
+    for (const session of sessions?.list?.() ?? [])
+        headers.set(session.header.id, session.header);
+    const persistence = ctx.get('sessionPersistence');
+    for (const header of (await persistence?.list?.()) ?? []) {
+        if (!headers.has(header.id))
+            headers.set(header.id, header);
+    }
+    let attached = 0;
+    let failed = 0;
+    for (const header of headers.values()) {
+        if (header.cwd === undefined)
+            continue;
+        const canonical = await canonicalCwd(header.cwd);
+        const ws = byPath.get(canonical);
+        if (ws === undefined || !ws.attachSession)
+            continue;
+        if (ws.sessionIds.includes(header.id))
+            continue;
+        try {
+            await ws.attachSession(header.id);
+            attached++;
+            console.log(`[harness-mcp-server] 存量捞回: session ${header.id} -> workspace ${ws.path}`);
+        }
+        catch (e) {
+            failed++;
+            console.warn(`[harness-mcp-server] 存量捞回失败 session ${header.id}:`, e?.message ?? e);
+        }
+    }
+    return { attached, failed };
 }
-//#endregion
-export { apply, inject, name };
+/** 在给定 McpServer 上注册工具 */
+function registerTools(mcp, ctx) {
+    mcp.tool('echo', '回显输入, 验证 MCP server 连通', { text: z.string() }, async ({ text }) => {
+        return out(`收到: ${text} @ ${Date.now()}`);
+    });
+    mcp.tool('harness_list_tools', '列出 Harness 当前注册的所有工具名', {}, async () => {
+        const tools = ctx.tools;
+        const names = tools && typeof tools.keys === 'function' ? Array.from(tools.keys()) : [];
+        return out(JSON.stringify(names));
+    });
+    // 同步执行任务(简单场景: Hermes 下发 → 立即拿结果)
+    mcp.tool('agent_run', '同步执行任务(改代码/分析/跑命令), 返回结构化结果。可传 sessionId 续接已有会话(长任务分多轮投喂)。', {
+        task: z.string().describe('要 Harness 执行的自然语言任务'),
+        context: z.string().optional().describe('Hermes 记忆/上下文, 注入给 agent 参考'),
+        cwd: z.string().optional().describe('工作目录(默认当前)'),
+        sessionId: z.string().optional().describe('续接已有会话的 sessionId(来自上次 agent_run 结果里的 sessionId 字段)'),
+        title: z.string().optional().describe('新会话的标题(创建时命名, 便于会话列表归档)'),
+    }, async ({ task, context, cwd, sessionId, title }) => {
+        const result = await executeTask(ctx, task, context ?? '', cwd ?? process.cwd(), sessionId, title);
+        return out(JSON.stringify(truncateResult(result), null, 2));
+    });
+    // 异步 push 任务到队列(Hermes → Harness 任务入口)
+    mcp.tool('task_inbox', 'Hermes 把结构化任务(任务+记忆上下文)推入 Harness 队列, 异步执行, 返回 taskId。记忆喂编码的入口。', {
+        task: z.string().describe('任务内容'),
+        context: z.string().optional().describe('Hermes 记忆/上下文, 随任务注入给 agent'),
+        cwd: z.string().optional().describe('工作目录'),
+        sessionId: z.string().optional().describe('续接已有会话的 sessionId(来自上次 agent_run 结果)'),
+        title: z.string().optional().describe('新会话的标题(创建时命名)'),
+    }, async ({ task, context, cwd, sessionId, title }) => {
+        const now = Date.now();
+        // TTL 清理: 删除已完成/失败且超时的任务
+        for (const [tid, t] of taskQueue) {
+            if ((t.status === 'done' || t.status === 'error') && t.finishedAt && now - t.finishedAt > runtimeConfig.taskTtlMs) {
+                taskQueue.delete(tid);
+            }
+        }
+        // 队列容量上限: 活动任务(排队+执行中)超过上限则拒绝
+        let active = 0;
+        for (const t of taskQueue.values())
+            if (t.status === 'queued' || t.status === 'running')
+                active++;
+        if (active >= runtimeConfig.maxQueue) {
+            return out(JSON.stringify({ error: `task queue full (${active}/${runtimeConfig.maxQueue})` }));
+        }
+        const id = randomUUID();
+        const item = {
+            id, task, context: context ?? '', cwd: cwd ?? process.cwd(), status: 'queued', createdAt: now,
+            ...(sessionId ? { sessionId } : {}),
+            ...(title ? { title } : {}),
+        };
+        taskQueue.set(id, item);
+        // 异步执行(不阻塞 Hermes)
+        void (async () => {
+            item.status = 'running';
+            try {
+                item.result = await executeTask(ctx, item.task, item.context, item.cwd, item.sessionId, item.title);
+                item.result.taskId = id;
+                item.status = 'done';
+            }
+            catch (e) {
+                item.error = String(e);
+                item.status = 'error';
+            }
+            item.finishedAt = Date.now();
+        })();
+        return out(JSON.stringify({ taskId: id, status: 'queued' }));
+    });
+    // 取回任务结果(结构化 changes/verification/leftovers)
+    mcp.tool('task_result', '取回 task_inbox 提交任务的结构化结果(changes/verification/leftovers)。', { taskId: z.string().describe('task_inbox 返回的 taskId') }, async ({ taskId }) => {
+        const item = taskQueue.get(taskId);
+        if (!item)
+            return out(JSON.stringify({ error: `task not found: ${taskId}` }));
+        return out(JSON.stringify({
+            taskId: item.id,
+            status: item.status,
+            error: item.error,
+            result: item.result ? truncateResult(item.result) : undefined,
+        }, null, 2));
+    });
+    // 给已有会话改名(走 sessionTitle 服务, 便于会话列表归档)
+    mcp.tool('rename_session', '给已有会话改名(走 sessionTitle 服务的 rename), 便于会话列表归档区分。', {
+        sessionId: z.string().describe('要改名的会话 id(来自 agent_run 结果里的 sessionId 字段)'),
+        title: z.string().describe('新标题'),
+    }, async ({ sessionId, title }) => {
+        try {
+            const sessions = ctx.get('sessions');
+            const session = sessions?.get?.(sessionId);
+            if (!session)
+                return out(JSON.stringify({ error: `session not found: ${sessionId}` }));
+            const st = ctx.get('sessionTitle');
+            if (!st?.rename)
+                return out(JSON.stringify({ error: 'sessionTitle service unavailable' }));
+            const snapshot = st.rename(session, title);
+            return out(JSON.stringify({ ok: true, sessionId, title: snapshot?.title ?? title }));
+        }
+        catch (e) {
+            return out(JSON.stringify({ error: String(e) }));
+        }
+    });
+    // 手动归组补给站: 官方 UI 没有"移动会话到工作区"功能, 本工具供随时归组
+    mcp.tool('attach_session', '把会话归组到工作区(补给站: 官方 UI 无移动会话功能)。path 缺省用该会话 header 的 cwd; 归组依赖官方 attachSession 的强校验——realpath(header.cwd) 必须与工作区路径精确相等, 不匹配会返回官方报错。', {
+        sessionId: z.string().describe('要归组的会话 id(live 或已持久化)'),
+        path: z.string().optional().describe('目标工作区目录(缺省: 会话 header 的 cwd)'),
+    }, async ({ sessionId, path }) => {
+        const sid = SessionId(sessionId);
+        const header = await findSessionHeader(ctx, sid);
+        if (header === undefined) {
+            return out(JSON.stringify({ error: `session not found: ${sessionId}(live 与持久化里都没有)` }));
+        }
+        const target = path ?? header.cwd;
+        if (target === undefined) {
+            return out(JSON.stringify({ error: `session ${sessionId} 的 header 没有 cwd, 官方 attachSession 无法校验, 不能归组` }));
+        }
+        try {
+            const canonical = await realpath(target); // 目标必须是存在的目录, 否则 ENOENT
+            const ws = await ensureWorkspace(ctx, canonical);
+            if (!ws?.attachSession)
+                return out(JSON.stringify({ error: 'workspaceRegistry unavailable' }));
+            if (ws.sessionIds.includes(sid)) {
+                return out(JSON.stringify({ sessionId, workspaceId: ws.id, workspacePath: ws.path, attached: false, note: 'already attached' }));
+            }
+            await ws.attachSession(sid);
+            return out(JSON.stringify({ sessionId, workspaceId: ws.id, workspacePath: ws.path, attached: true }));
+        }
+        catch (e) {
+            return out(JSON.stringify({ error: `attach failed: ${e?.message ?? String(e)}` }));
+        }
+    });
+}
+/**
+ * 插件入口: 启动 MCP server(StreamableHTTP, 跨网), 通过 ctx 桥接 Harness 能力。
+ */
+export async function apply(ctx, config = {}) {
+    // 初始化运行时配置(覆盖默认值)
+    if (config.provider)
+        runtimeConfig.provider = config.provider;
+    if (config.model)
+        runtimeConfig.model = config.model;
+    if (config.preset)
+        runtimeConfig.preset = config.preset;
+    if (config.maxQueue !== undefined)
+        runtimeConfig.maxQueue = config.maxQueue;
+    if (config.taskTtlMs !== undefined)
+        runtimeConfig.taskTtlMs = config.taskTtlMs;
+    if (config.maxAgents !== undefined)
+        runtimeConfig.maxAgents = config.maxAgents;
+    if (config.authToken)
+        runtimeConfig.authToken = config.authToken;
+    if (config.workspaceRoots)
+        runtimeConfig.workspaceRoots = config.workspaceRoots;
+    const port = config.port ?? 8090;
+    // 安全默认: 仅监听本机。暴露公网/局域网前必须自行加认证+反代+TLS(见 README 警告)
+    const host = config.host ?? '127.0.0.1';
+    console.log('[harness-mcp-server] apply called, port=', port);
+    const servers = new Map();
+    const transports = new Map();
+    const server = http.createServer(async (req, res) => {
+        // Bearer token 认证(配置了 authToken 时强制所有请求校验)
+        if (runtimeConfig.authToken) {
+            const auth = req.headers['authorization'];
+            if (auth !== `Bearer ${runtimeConfig.authToken}`) {
+                res.writeHead(401, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Unauthorized' }, id: null }));
+                return;
+            }
+        }
+        const sessionId = req.headers['mcp-session-id'] ?? undefined;
+        const existing = sessionId ? transports.get(sessionId) : undefined;
+        // 已有 session: GET/POST/DELETE 都路由到对应 transport(支持 SSE 流 + 会话终止)
+        if (existing) {
+            if (req.method === 'GET' || req.method === 'POST' || req.method === 'DELETE') {
+                await existing.handleRequest(req, res);
+                return;
+            }
+            res.writeHead(405, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32600, message: 'Method not allowed' }, id: null }));
+            return;
+        }
+        // 新 session 初始化(仅 POST 且无 session id)
+        if (req.method === 'POST' && !sessionId) {
+            const mcp = new McpServer({ name: 'harness', version: '0.1.9' });
+            registerTools(mcp, ctx);
+            const transport = new StreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                onsessioninitialized: (sid) => {
+                    transports.set(sid, transport);
+                    servers.set(sid, mcp);
+                },
+            });
+            // 会话关闭时清理映射(避免临时 key 泄漏 + 无效会话累积)
+            transport.onclose = () => {
+                const sid = transport.sessionId;
+                if (sid) {
+                    transports.delete(sid);
+                    servers.delete(sid);
+                }
+            };
+            await mcp.connect(transport);
+            await transport.handleRequest(req, res);
+            return;
+        }
+        // 未知 session → 404(不新建 transport, 避免遗留对象)
+        if (sessionId) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }));
+            return;
+        }
+        // 无 session 的非初始化请求 → 400
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32600, message: 'Invalid request' }, id: null }));
+    });
+    server.listen(port, host, () => {
+        console.log(`[harness-mcp-server] MCP server listening on ${host}:${port}`);
+    });
+    server.on('error', (e) => {
+        console.error('[harness-mcp-server] HTTP server error:', e.message);
+    });
+    // 存量捞回: 启动后异步补挂未分组会话, 不阻塞启动; 全程兜底 try/catch 防 unhandled rejection
+    void (async () => {
+        try {
+            const r = await reattachOrphanSessions(ctx);
+            console.log(`[harness-mcp-server] 存量捞回完成: attached=${r.attached} failed=${r.failed}`);
+        }
+        catch (e) {
+            console.warn('[harness-mcp-server] 存量捞回异常:', e?.message ?? e);
+        }
+    })();
+    // 标准 cordis 生命周期: 用 ctx.effect 注册清理(卸载时关 server + 清空全部映射/会话/队列)
+    ctx.effect(() => {
+        return () => {
+            server.close();
+            transports.clear();
+            servers.clear();
+            liveAgents.clear();
+            sessionToCwd.clear();
+            agentLocks.clear();
+            taskQueue.clear();
+        };
+    }, 'harness-mcp-server');
+}

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -7,13 +7,24 @@
  *   - agent_run           : 同步执行任务(改代码/分析/跑命令), 返回结构化结果
  *   - task_inbox          : Hermes push 结构化任务(任务+记忆上下文)到 Harness 队列, 异步执行, 返回 taskId
  *   - task_result         : 取回任务的结构化结果(changes/verification/leftovers)
+ *   - attach_session      : 把会话归组到其 cwd 对应的工作区(手动补给站)
+ *   - rename_session      : 给已有会话改名
+ *
+ * sessionId 续接: 指定 sessionId 时按 本进程池 → live 会话(UI 手开)→ 持久化 resume 三级接管,
+ * 前两者都找不到才报错, 所以进程重启前/UI 手开的会话也能续接。
+ * 工作区分组: cwd 先 realpath 规范化再 `workspaceRegistry.resolveByPath ?? create` + attachSession;
+ * 启动时对存量未分组会话补挂一次(存量捞回)。
  *
  * 回路: Hermes 记忆 →(context)→ task_inbox → Harness agent 执行 → 结果进队列 → task_result → Hermes 持久化
  */
 import type { Context } from '@deepseek-ai/cordis';
 /** Cordis 插件名 */
 export declare const name = "harness-mcp-server";
-/** 声明依赖的核心服务 */
+/**
+ * 声明依赖的核心服务。
+ * workspaceRegistry/sessionPersistence/sessions 是续接/归组三个增量用到的服务——
+ * 漏声明会在真实启动时拿不到服务(本插件曾经踩过, 务必与代码里的 ctx.get 对齐)。
+ */
 export declare const inject: string[];
 /** 插件配置 */
 export interface Config {
@@ -41,4 +52,3 @@ export interface Config {
  * 插件入口: 启动 MCP server(StreamableHTTP, 跨网), 通过 ctx 桥接 Harness 能力。
  */
 export declare function apply(ctx: Context, config?: Config): Promise<void>;
-//# sourceMappingURL=index.d.ts.map

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -7,6 +7,13 @@
  *   - agent_run           : 同步执行任务(改代码/分析/跑命令), 返回结构化结果
  *   - task_inbox          : Hermes push 结构化任务(任务+记忆上下文)到 Harness 队列, 异步执行, 返回 taskId
  *   - task_result         : 取回任务的结构化结果(changes/verification/leftovers)
+ *   - attach_session      : 把会话归组到其 cwd 对应的工作区(手动补给站)
+ *   - rename_session      : 给已有会话改名
+ *
+ * sessionId 续接: 指定 sessionId 时按 本进程池 → live 会话(UI 手开)→ 持久化 resume 三级接管,
+ * 前两者都找不到才报错, 所以进程重启前/UI 手开的会话也能续接。
+ * 工作区分组: cwd 先 realpath 规范化再 `workspaceRegistry.resolveByPath ?? create` + attachSession;
+ * 启动时对存量未分组会话补挂一次(存量捞回)。
  *
  * 回路: Hermes 记忆 →(context)→ task_inbox → Harness agent 执行 → 结果进队列 → task_result → Hermes 持久化
  */
@@ -17,12 +24,17 @@ import { scopeOf } from '@deepseek-ai/dsh-scope';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { randomUUID } from 'node:crypto';
+import { realpath } from 'node:fs/promises';
 import http from 'node:http';
 import { resolve } from 'node:path';
 /** Cordis 插件名 */
 export const name = 'harness-mcp-server';
-/** 声明依赖的核心服务 */
-export const inject = ['tools', 'llm', 'agents', 'agentPresets'];
+/**
+ * 声明依赖的核心服务。
+ * workspaceRegistry/sessionPersistence/sessions 是续接/归组三个增量用到的服务——
+ * 漏声明会在真实启动时拿不到服务(本插件曾经踩过, 务必与代码里的 ctx.get 对齐)。
+ */
+export const inject = ['tools', 'llm', 'agents', 'agentPresets', 'workspaceRegistry', 'sessionPersistence', 'sessions'];
 /** 运行时配置(apply 时从 config 初始化, 提供安全默认值) */
 const runtimeConfig = {
     provider: 'deepseek-official',
@@ -39,16 +51,54 @@ const runtimeConfig = {
 function out(content) {
     return { content: [{ type: 'text', text: content }] };
 }
+/**
+ * cwd realpath 规范化: 解析符号链接与 .. 段, 使 cwd 能与 workspace.path(存储时为 realpath 规范化值)
+ * 精确比对——这是官方 attachSession 强校验通过的前提。目录不存在时回退 resolve 结果, 由调用方告警不阻断。
+ */
+async function canonicalCwd(raw) {
+    try {
+        return await realpath(raw);
+    }
+    catch {
+        return resolve(raw);
+    }
+}
+/** 官方 session.create RPC 同款姿势: resolveByPath ?? create, 幂等; 无 workspaceRegistry 时返回 undefined */
+async function ensureWorkspace(ctx, canonical) {
+    const registry = ctx.get('workspaceRegistry');
+    if (!registry)
+        return undefined;
+    return (await registry.resolveByPath?.(canonical)) ?? (await registry.create?.(canonical));
+}
+/** 把会话挂名到其 cwd 对应的工作区。attachSession 内部强校验 realpath(header.cwd) 精确等于 workspace.path,
+ *  所以 canonical 必须是 header.cwd 的 realpath 规范化值。失败告警不阻断任务(分组是锦上添花)。 */
+async function attachToWorkspace(ctx, canonical, sessionId) {
+    try {
+        const ws = await ensureWorkspace(ctx, canonical);
+        if (ws?.attachSession)
+            await ws.attachSession(sessionId);
+    }
+    catch (e) {
+        console.warn('[harness-mcp-server] workspace attach failed:', e?.message ?? e);
+    }
+}
+/** 按会话 header 的 cwd(realpath 规范化后)补挂工作区; header 无 cwd 时静默跳过 */
+async function attachSessionCwd(ctx, sessionId, cwd) {
+    if (cwd === undefined)
+        return;
+    await attachToWorkspace(ctx, await canonicalCwd(cwd), sessionId);
+}
 /** 常驻 agent 会话(按 cwd 复用, 省 token: 避免每次全量加载项目上下文) */
 const liveAgents = new Map();
 /** sessionId → cwd 索引(支持按 session 续接: 指定 sessionId 时定位到对应 cwd 的常驻会话) */
 const sessionToCwd = new Map();
 /** 每个 cwd 的串行执行锁(防同一 agent 会话被并发 followup 冲突) */
 const agentLocks = new Map();
-/** 获取(或创建)指定 cwd 的常驻 agent 会话; 传 sessionId 时续接指定会话; 传 title 时给新会话命名 */
+/** 获取(或创建)指定 cwd 的常驻 agent 会话; 传 sessionId 时接管指定会话; 传 title 时给新会话命名 */
 async function getAgent(ctx, cwd, sessionId, title) {
-    // 指定 sessionId: 续接已有会话(长任务分多轮投喂 / 中断后恢复)
+    // 指定 sessionId: 接管已有会话(长任务分多轮投喂 / 中断后恢复 / UI 手开的会话)
     if (sessionId) {
+        // 先看本进程常驻池(指定 sessionId 时定位到对应 cwd 的常驻会话; 命中 LRU 移到末尾, 保留上游语义)
         const targetCwd = sessionToCwd.get(sessionId);
         if (targetCwd !== undefined) {
             const existing = liveAgents.get(targetCwd);
@@ -58,14 +108,49 @@ async function getAgent(ctx, cwd, sessionId, title) {
                 return existing;
             }
         }
-        // 会话不在常驻表里(LRU 已淘汰或进程重启), 无法续接
-        throw new Error(`session not found for resume: ${sessionId} (evicted by LRU or process restarted)`);
+        const sid = SessionId(sessionId);
+        // 不在常驻池: 看 live(UI 手开的、别的插件持有的会话), 直接接管、不持有 dispose(归其 owner)
+        const live = ctx.agents.get(sid);
+        if (live) {
+            // live 会话也补挂工作区(幂等): 用户手开的会话若尚未归组, 这里一并挂名
+            await attachSessionCwd(ctx, sid, live.session.header.cwd);
+            // no-op dispose 兜底: executeTask 只在 disposeAfter 为 true 时调用 dispose
+            return { sessionId: sid, handle: { agent: live, dispose: () => Promise.resolve() }, disposeAfter: false };
+        }
+        // live 也没有: 从持久化会话存储 resume 并接管(进程重启前的会话、LRU 淘汰后被释放的会话)
+        let handle;
+        try {
+            handle = await ctx.agents.resume({
+                resumeSessionId: sid,
+                agentOptions: {
+                    provider: runtimeConfig.provider,
+                    // model 为空则省略, 让 dsh 跟随用户/默认设置; 显式配置则覆盖
+                    ...(runtimeConfig.model ? { model: runtimeConfig.model } : {}),
+                },
+                setup: async (agentCtx) => {
+                    // 同 create 路径: dsh rc.6 agent ctx 可能丢 scope tag, 检测不到就跳过挂载(降级为无工具 agent)
+                    if (scopeOf(agentCtx) === undefined) {
+                        console.warn('[harness-mcp-server] agent ctx unscoped (dsh rc.6 bug); preset mount skipped — upgrade dsh for full tool support');
+                        return;
+                    }
+                    await ctx.agentPresets.mount(agentCtx, runtimeConfig.preset);
+                },
+            });
+        }
+        catch (e) {
+            // 恢复失败返回明确错误(沿用上游错误风格): 不在常驻池、不是 live、持久化里也没有(或 resume 失败)
+            throw new Error(`session not found for resume: ${sessionId} (not live and not persisted; ${e?.message ?? e})`);
+        }
+        await attachSessionCwd(ctx, sid, handle.agent.session.header.cwd);
+        return { sessionId: sid, handle, disposeAfter: true };
     }
     const existing = liveAgents.get(cwd);
     if (existing) {
         // LRU: 命中则移到末尾(最近使用)
         liveAgents.delete(cwd);
         liveAgents.set(cwd, existing);
+        // 自愈: 幂等补挂(已在花名册则 no-op; 首次挂名失败的池会话在此被捞回)
+        await attachToWorkspace(ctx, await canonicalCwd(cwd), existing.sessionId);
         return existing;
     }
     // LRU 淘汰: 超过上限时逐出最久未用的会话
@@ -84,10 +169,13 @@ async function getAgent(ctx, cwd, sessionId, title) {
         }
     }
     const newSessionId = SessionId(randomUUID());
+    // cwd 先 realpath 规范化: session header 的 cwd 与 workspace.path 必须精确相等,
+    // 否则 attachSession 强校验 reject(只会 create 注册而 UI 仍落未分组)
+    const canonical = await canonicalCwd(cwd);
     const handle = await ctx.agents.create({
         sessionId: newSessionId,
         // 声明 preset: 为未来 Harness 版本消费 meta.agentPreset 做准备; 当前版本靠 setup 里手动 mount 兜底。
-        meta: { cwd, agentPreset: runtimeConfig.preset },
+        meta: { cwd: canonical, agentPreset: runtimeConfig.preset },
         agentOptions: {
             provider: runtimeConfig.provider,
             // model 为空则省略, 让 dsh 跟随用户/默认设置; 显式配置则覆盖
@@ -109,14 +197,12 @@ async function getAgent(ctx, cwd, sessionId, title) {
     const rec = { sessionId: newSessionId, handle };
     liveAgents.set(cwd, rec);
     sessionToCwd.set(String(newSessionId), cwd);
-    // 诉求3: 把会话归属到 cwd 对应的工作区分组(可选依赖; headless/无 workspaceRegistry 的环境自动跳过)
+    // 分组: 把会话归属到 cwd 对应的工作区(resolveByPath ?? create + attachSession; 可选依赖; headless 环境自动跳过)
     void (async () => {
         try {
-            const registry = ctx.get('workspaceRegistry');
-            if (registry?.create) {
-                const workspace = await registry.create(cwd);
-                await workspace.attachSession?.(newSessionId);
-            }
+            const ws = await ensureWorkspace(ctx, canonical);
+            if (ws?.attachSession)
+                await ws.attachSession(newSessionId);
         }
         catch (e) {
             console.warn('[harness-mcp-server] workspace attach failed:', String(e));
@@ -182,8 +268,9 @@ function truncateResult(result) {
 }
 /** 核心执行: 组装任务(注入记忆上下文+结构化要求) → agent 执行 → 读结构化结果 */
 async function executeTask(ctx, task, context, cwd, resumeSessionId, title) {
-    // 规范化 cwd, 避免 /a、/a/.、相对路径、符号链接成为不同 Map key 导致重复创建会话/并发冲突
-    const workdir = cwd ? resolve(cwd) : process.cwd();
+    // 规范化 cwd: realpath 解析符号链接与 .. 段, 避免 /a、/a/.、相对路径、符号链接成为不同 Map key
+    // 导致重复创建会话/并发冲突; 同时也是与 workspace.path 精确比对的唯一 canon
+    const workdir = await canonicalCwd(cwd ? resolve(cwd) : process.cwd());
     // cwd 白名单: 配置了 workspaceRoots 时, 只允许在列出的目录下干活(防路径穿越)
     if (runtimeConfig.workspaceRoots.length > 0) {
         const allowed = runtimeConfig.workspaceRoots.some((root) => {
@@ -194,8 +281,10 @@ async function executeTask(ctx, task, context, cwd, resumeSessionId, title) {
             throw new Error(`cwd not allowed (outside workspaceRoots): ${workdir}`);
         }
     }
-    return withLock(workdir, async () => {
-        const { sessionId, handle } = await getAgent(ctx, workdir, resumeSessionId, title);
+    // sessionId 用 session 锁, 否则用 cwd 锁——都防同一 agent 会话被并发 followup
+    const lockKey = resumeSessionId ? `session:${resumeSessionId}` : workdir;
+    return withLock(lockKey, async () => {
+        const { sessionId, handle, disposeAfter } = await getAgent(ctx, workdir, resumeSessionId, title);
         const baseline = (handle.agent.session.log ?? []).length;
         // 组装完整任务文本: 记忆上下文 + 任务 + 结构化输出要求
         const fullTask = [
@@ -262,10 +351,83 @@ async function executeTask(ctx, task, context, cwd, resumeSessionId, title) {
         result.changes = summary.changes;
         result.verification = summary.verification;
         result.leftovers = summary.leftovers;
+        // resume 兜底分支: 尽力 flush 持久化, 再释放我们 resume 出来的句柄(不留给僵尸 live agent)
+        if (disposeAfter) {
+            try {
+                await ctx.get('sessions')?.flush?.(handle.agent.session);
+            }
+            catch {
+                /* flush 失败不阻断结果返回 */
+            }
+            try {
+                await handle.dispose();
+            }
+            catch {
+                /* 释放失败不影响结果 */
+            }
+        }
         return result;
     });
 }
 const taskQueue = new Map();
+/** 找会话 header: live 优先, 其次持久化 list(轻量元数据扫描, 不加载整日志) */
+async function findSessionHeader(ctx, sessionId) {
+    const sessions = ctx.get('sessions');
+    const live = sessions?.get?.(sessionId);
+    if (live !== undefined)
+        return live.header;
+    const persistence = ctx.get('sessionPersistence');
+    for (const header of (await persistence?.list?.()) ?? []) {
+        if (header.id === sessionId)
+            return header;
+    }
+    return undefined;
+}
+/**
+ * 存量捞回: 启动时把现存未分组的会话补挂到已注册工作区。
+ * 条件: header.cwd 的 realpath 等于某已注册 workspace.path, 且该 sessionId 不在其花名册里。
+ * 只补挂到"已注册"工作区, 不新建(避免把无关目录刷成新工作区); 单会话失败不影响其余。
+ */
+async function reattachOrphanSessions(ctx) {
+    const registry = ctx.get('workspaceRegistry');
+    const byPath = new Map();
+    for (const ws of registry?.list?.() ?? [])
+        byPath.set(ws.path, ws);
+    if (byPath.size === 0)
+        return { attached: 0, failed: 0 };
+    // live + 持久化 header 合并(live 优先), 按 id 去重
+    const headers = new Map();
+    const sessions = ctx.get('sessions');
+    for (const session of sessions?.list?.() ?? [])
+        headers.set(session.header.id, session.header);
+    const persistence = ctx.get('sessionPersistence');
+    for (const header of (await persistence?.list?.()) ?? []) {
+        if (!headers.has(header.id))
+            headers.set(header.id, header);
+    }
+    let attached = 0;
+    let failed = 0;
+    for (const header of headers.values()) {
+        if (header.cwd === undefined)
+            continue;
+        const canonical = await canonicalCwd(header.cwd);
+        const ws = byPath.get(canonical);
+        if (ws === undefined || !ws.attachSession)
+            continue;
+        if (ws.sessionIds.includes(header.id))
+            continue;
+        try {
+            await ws.attachSession(header.id);
+            attached++;
+            console.log(`[harness-mcp-server] 存量捞回: session ${header.id} -> workspace ${ws.path}`);
+        }
+        catch (e) {
+            failed++;
+            console.warn(`[harness-mcp-server] 存量捞回失败 session ${header.id}:`, e?.message ?? e);
+        }
+    }
+    return { attached, failed };
+}
 /** 在给定 McpServer 上注册工具 */
 function registerTools(mcp, ctx) {
     mcp.tool('echo', '回显输入, 验证 MCP server 连通', { text: z.string() }, async ({ text }) => {
@@ -365,6 +527,35 @@ function registerTools(mcp, ctx) {
             return out(JSON.stringify({ error: String(e) }));
         }
     });
+    // 手动归组补给站: 官方 UI 没有"移动会话到工作区"功能, 本工具供随时归组
+    mcp.tool('attach_session', '把会话归组到工作区(补给站: 官方 UI 无移动会话功能)。path 缺省用该会话 header 的 cwd; 归组依赖官方 attachSession 的强校验——realpath(header.cwd) 必须与工作区路径精确相等, 不匹配会返回官方报错。', {
+        sessionId: z.string().describe('要归组的会话 id(live 或已持久化)'),
+        path: z.string().optional().describe('目标工作区目录(缺省: 会话 header 的 cwd)'),
+    }, async ({ sessionId, path }) => {
+        const sid = SessionId(sessionId);
+        const header = await findSessionHeader(ctx, sid);
+        if (header === undefined) {
+            return out(JSON.stringify({ error: `session not found: ${sessionId}(live 与持久化里都没有)` }));
+        }
+        const target = path ?? header.cwd;
+        if (target === undefined) {
+            return out(JSON.stringify({ error: `session ${sessionId} 的 header 没有 cwd, 官方 attachSession 无法校验, 不能归组` }));
+        }
+        try {
+            const canonical = await realpath(target); // 目标必须是存在的目录, 否则 ENOENT
+            const ws = await ensureWorkspace(ctx, canonical);
+            if (!ws?.attachSession)
+                return out(JSON.stringify({ error: 'workspaceRegistry unavailable' }));
+            if (ws.sessionIds.includes(sid)) {
+                return out(JSON.stringify({ sessionId, workspaceId: ws.id, workspacePath: ws.path, attached: false, note: 'already attached' }));
+            }
+            await ws.attachSession(sid);
+            return out(JSON.stringify({ sessionId, workspaceId: ws.id, workspacePath: ws.path, attached: true }));
+        }
+        catch (e) {
+            return out(JSON.stringify({ error: `attach failed: ${e?.message ?? String(e)}` }));
+        }
+    });
 }
 /**
  * 插件入口: 启动 MCP server(StreamableHTTP, 跨网), 通过 ctx 桥接 Harness 能力。
@@ -454,6 +645,16 @@ export async function apply(ctx, config = {}) {
     server.on('error', (e) => {
         console.error('[harness-mcp-server] HTTP server error:', e.message);
     });
+    // 存量捞回: 启动后异步补挂未分组会话, 不阻塞启动; 全程兜底 try/catch 防 unhandled rejection
+    void (async () => {
+        try {
+            const r = await reattachOrphanSessions(ctx);
+            console.log(`[harness-mcp-server] 存量捞回完成: attached=${r.attached} failed=${r.failed}`);
+        }
+        catch (e) {
+            console.warn('[harness-mcp-server] 存量捞回异常:', e?.message ?? e);
+        }
+    })();
     // 标准 cordis 生命周期: 用 ctx.effect 注册清理(卸载时关 server + 清空全部映射/会话/队列)
     ctx.effect(() => {
         return () => {
@@ -467,4 +668,3 @@ export async function apply(ctx, config = {}) {
         };
     }, 'harness-mcp-server');
 }
-//# sourceMappingURL=index.js.map

--- a/smoke.mjs
+++ b/smoke.mjs
@@ -1,0 +1,183 @@
+// Dev-only smoke test (not shipped): drives apply() with a minimal fake ctx and verifies the
+// three increments ported onto upstream v0.1.9:
+//   1. 任意会话续接: live 接管 / 持久化 resume / 明确报错(三级)
+//   2. realpath 规范化: create 的 meta.cwd 为 realpath 值; 目录不存在时回退 resolve 不阻断
+//   3. attach_session 工具 + 启动存量捞回(workspaceRegistry/sessions/sessionPersistence 三服务路径)
+import { realpathSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { apply } from './lib/index.js'
+
+const attachedIds = []
+const created = []
+const resumed = []
+const disposed = []
+const flushed = []
+
+// smoke 文件所在目录的 realpath(win32 反斜杠规范路径) —— 与 workspace.path / fs.realpath 结果同 canon
+const FAKE_CWD = realpathSync(new URL('.', import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1'))
+
+const fakeWs = {
+  id: 'ws-fake',
+  title: 'fake',
+  path: FAKE_CWD,
+  sessionIds: [],
+  attachSession: async (id) => { attachedIds.push(id) },
+}
+const wsRegistry = {
+  list: () => [fakeWs],
+  resolveByPath: async (p) => (p === FAKE_CWD ? fakeWs : undefined),
+  create: async () => fakeWs,
+}
+
+function makeAgent(id, cwd) {
+  return {
+    session: { id, log: [], events: [], header: { version: 0, id, createdAt: Date.now(), cwd } },
+    followup: () => {},
+    whenIdle: async () => {},
+  }
+}
+
+const liveAgent = makeAgent('sess-live', FAKE_CWD)
+const liveSession2 = { id: 'sess-live2', log: [], events: [], header: { version: 0, id: 'sess-live2', createdAt: 1, cwd: FAKE_CWD } }
+
+const fakeSessions = {
+  get: (id) => (id === 'sess-live' ? liveAgent.session : id === 'sess-live2' ? liveSession2 : undefined),
+  list: () => [liveSession2],
+  flush: async (session) => { flushed.push(session.id); return true },
+}
+const fakePersistence = {
+  list: async () => [{ version: 0, id: 'sess-persisted', createdAt: 1, cwd: FAKE_CWD }],
+}
+
+const ctx = {
+  tools: { keys: () => [] },
+  llm: {},
+  agents: {
+    get: (id) => (id === 'sess-live' ? liveAgent : undefined),
+    create: async ({ sessionId, meta }) => {
+      const id = String(sessionId)
+      created.push({ id, cwd: meta?.cwd })
+      return { agent: makeAgent(id, meta?.cwd), dispose: async () => { disposed.push(id) } }
+    },
+    resume: async ({ resumeSessionId }) => {
+      const id = String(resumeSessionId)
+      if (id !== 'sess-persisted') throw new Error(`no persisted session "${id}"`)
+      resumed.push(id)
+      return { agent: makeAgent(id, FAKE_CWD), dispose: async () => { disposed.push(id) } }
+    },
+  },
+  agentPresets: { mount: async () => ({ id: 'standard' }) },
+  sessions: fakeSessions,
+  sessionPersistence: fakePersistence,
+  workspaceRegistry: wsRegistry,
+  effect: (fn) => { disposer = fn(); return disposer },
+  get: (name) => (name === 'workspaceRegistry' ? wsRegistry
+    : name === 'sessions' ? fakeSessions
+    : name === 'sessionPersistence' ? fakePersistence
+    : undefined),
+}
+let disposer = () => {}
+
+const PORT = 8099
+const BASE = `http://127.0.0.1:${PORT}/mcp`
+
+async function rpc(sessionId, body) {
+  const res = await fetch(BASE, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...(sessionId ? { 'Mcp-Session-Id': sessionId } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+  const sid = res.headers.get('mcp-session-id') ?? sessionId
+  const text = await res.text()
+  return { sid, status: res.status, text }
+}
+
+function parsePayload(text) {
+  for (const line of text.split('\n')) {
+    const t = line.trim()
+    if (t.startsWith('data: ')) return JSON.parse(t.slice(6))
+  }
+  return JSON.parse(text)
+}
+
+// 解出 MCP envelope 里的内层 JSON(text content 是 out() 字符串); isError 结果取错误文本
+function innerOf(resp) {
+  const payload = parsePayload(resp.text)
+  if (payload.error) return { error: payload.error.message }
+  const r = payload.result
+  if (r.isError) return { error: r.content?.[0]?.text ?? 'isError' }
+  return JSON.parse(r.content[0].text)
+}
+
+const checks = {}
+try {
+  await apply(ctx, { port: PORT, host: '127.0.0.1' })
+  await new Promise((r) => setTimeout(r, 400))
+
+  const init = await rpc(undefined, {
+    jsonrpc: '2.0', id: 1, method: 'initialize',
+    params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'smoke', version: '1.0' } },
+  })
+  checks['initialize 拿到 sessionId'] = Boolean(init.sid)
+  await rpc(init.sid, { jsonrpc: '2.0', method: 'notifications/initialized' })
+
+  const echo = await rpc(init.sid, { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'echo', arguments: { text: 'ping-8099' } } })
+  checks['echo 通'] = echo.status === 200 && echo.text.includes('ping-8099')
+
+  const toolsList = await rpc(init.sid, { jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} })
+  const toolNames = parsePayload(toolsList.text).result?.tools?.map((t) => t.name) ?? []
+  checks['attach_session 在工具清单里'] = toolNames.includes('attach_session')
+
+  // ── 增量3: attach_session 工具(live / 持久化 / 未知三态) ──
+  const attachLive = await rpc(init.sid, { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'attach_session', arguments: { sessionId: 'sess-live' } } })
+  checks['attach_session live 会话'] = attachLive.status === 200 && innerOf(attachLive).attached === true
+
+  const attachMissing = await rpc(init.sid, { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'attach_session', arguments: { sessionId: 'sess-nope' } } })
+  checks['attach_session 未知会话报错'] = attachMissing.status === 200 && typeof innerOf(attachMissing).error === 'string'
+
+  const attachPersisted = await rpc(init.sid, { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'attach_session', arguments: { sessionId: 'sess-persisted' } } })
+  checks['attach_session 持久化会话(经 sessionPersistence)'] = attachPersisted.status === 200 && innerOf(attachPersisted).attached === true
+
+  // ── 增量1: 任意会话续接三级 ──
+  const runLive = await rpc(init.sid, { jsonrpc: '2.0', id: 7, method: 'tools/call', params: { name: 'agent_run', arguments: { task: 'say ok', sessionId: 'sess-live' } } })
+  const runLiveInner = runLive.status === 200 ? innerOf(runLive) : { error: 'bad' }
+  checks['agent_run 接管 live 会话(不 resume 不 dispose)'] = runLiveInner.sessionId === 'sess-live' && resumed.length === 0 && disposed.length === 0
+
+  const runPersisted = await rpc(init.sid, { jsonrpc: '2.0', id: 8, method: 'tools/call', params: { name: 'agent_run', arguments: { task: 'say ok', sessionId: 'sess-persisted' } } })
+  const runPersistedInner = runPersisted.status === 200 ? innerOf(runPersisted) : { error: 'bad' }
+  checks['agent_run 持久化会话 resume + flush + dispose'] = runPersistedInner.sessionId === 'sess-persisted'
+    && resumed.includes('sess-persisted') && flushed.includes('sess-persisted') && disposed.includes('sess-persisted')
+
+  const runUnknown = await rpc(init.sid, { jsonrpc: '2.0', id: 9, method: 'tools/call', params: { name: 'agent_run', arguments: { task: 'say ok', sessionId: 'sess-unknown' } } })
+  checks['agent_run 未知会话明确报错'] = runUnknown.status === 200 && String(innerOf(runUnknown).error ?? '').includes('session not found for resume')
+
+  // ── 增量2: realpath 规范化 ──
+  const runNew = await rpc(init.sid, { jsonrpc: '2.0', id: 10, method: 'tools/call', params: { name: 'agent_run', arguments: { task: 'say ok', cwd: FAKE_CWD } } })
+  const runNewInner = runNew.status === 200 ? innerOf(runNew) : { error: 'bad' }
+  checks['agent_run 池新建: meta.cwd 为 realpath 值'] = Boolean(created[0]) && created[0].cwd === FAKE_CWD && runNewInner.sessionId === created[0].id
+
+  const missingDir = resolve(FAKE_CWD, 'nonexistent-xyz')
+  const runMissingCwd = await rpc(init.sid, { jsonrpc: '2.0', id: 11, method: 'tools/call', params: { name: 'agent_run', arguments: { task: 'say ok', cwd: missingDir } } })
+  const runMissingInner = runMissingCwd.status === 200 ? innerOf(runMissingCwd) : { error: 'bad' }
+  checks['目录不存在: realpath 回退 resolve 且不阻断'] = Boolean(runMissingInner.sessionId) && created[1]?.cwd === missingDir
+
+  // ── 增量3: 启动存量捞回(sessions.list + sessionPersistence.list 两源) ──
+  await new Promise((r) => setTimeout(r, 500))
+  checks['存量捞回: live 列表会话补挂'] = attachedIds.includes('sess-live2')
+  checks['存量捞回: 持久化会话补挂'] = attachedIds.includes('sess-persisted')
+
+  const failed = Object.entries(checks).filter(([, ok]) => !ok)
+  for (const [name, ok] of Object.entries(checks)) console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}`)
+  console.log('attach_session 路径记录:', JSON.stringify(attachedIds))
+  console.log(failed.length === 0 ? 'SMOKE PASS' : `SMOKE FAIL (${failed.length} 项)`)
+  disposer()
+  await new Promise((r) => setTimeout(r, 100))
+  process.exit(failed.length === 0 ? 0 : 1)
+} catch (e) {
+  console.error('SMOKE ERROR:', e)
+  process.exit(1)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,13 @@
  *   - agent_run           : 同步执行任务(改代码/分析/跑命令), 返回结构化结果
  *   - task_inbox          : Hermes push 结构化任务(任务+记忆上下文)到 Harness 队列, 异步执行, 返回 taskId
  *   - task_result         : 取回任务的结构化结果(changes/verification/leftovers)
+ *   - attach_session      : 把会话归组到其 cwd 对应的工作区(手动补给站)
+ *   - rename_session      : 给已有会话改名
+ *
+ * sessionId 续接: 指定 sessionId 时按 本进程池 → live 会话(UI 手开)→ 持久化 resume 三级接管,
+ * 前两者都找不到才报错, 所以进程重启前/UI 手开的会话也能续接。
+ * 工作区分组: cwd 先 realpath 规范化再 `workspaceRegistry.resolveByPath ?? create` + attachSession;
+ * 启动时对存量未分组会话补挂一次(存量捞回)。
  *
  * 回路: Hermes 记忆 →(context)→ task_inbox → Harness agent 执行 → 结果进队列 → task_result → Hermes 持久化
  */
@@ -22,18 +29,24 @@ import type { AgentHandle } from '@deepseek-ai/dsh-agent'
 import { z } from 'zod'
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
 import { SessionId } from '@deepseek-ai/dsh-session'
+import type { SessionHeader } from '@deepseek-ai/dsh-session'
 import { scopeOf } from '@deepseek-ai/dsh-scope'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { randomUUID } from 'node:crypto'
+import { realpath } from 'node:fs/promises'
 import http from 'node:http'
 import { resolve } from 'node:path'
 
 /** Cordis 插件名 */
 export const name = 'harness-mcp-server'
 
-/** 声明依赖的核心服务 */
-export const inject = ['tools', 'llm', 'agents', 'agentPresets']
+/**
+ * 声明依赖的核心服务。
+ * workspaceRegistry/sessionPersistence/sessions 是续接/归组三个增量用到的服务——
+ * 漏声明会在真实启动时拿不到服务(本插件曾经踩过, 务必与代码里的 ctx.get 对齐)。
+ */
+export const inject = ['tools', 'llm', 'agents', 'agentPresets', 'workspaceRegistry', 'sessionPersistence', 'sessions']
 
 /** 插件配置 */
 export interface Config {
@@ -76,6 +89,55 @@ function out(content: string) {
   return { content: [{ type: 'text' as const, text: content }] }
 }
 
+/** 工作区视图(ctx.get('workspaceRegistry')): 可选依赖, headless/无 workspace 插件的环境自动跳过 */
+interface WorkspaceView {
+  id: string
+  path: string
+  sessionIds: readonly SessionId[]
+  attachSession?: (sessionId: SessionId) => Promise<void>
+}
+interface WorkspaceRegistryView {
+  create?: (path: string) => Promise<WorkspaceView>
+  resolveByPath?: (path: string) => Promise<WorkspaceView | undefined>
+  list?: () => WorkspaceView[]
+}
+
+/**
+ * cwd realpath 规范化: 解析符号链接与 .. 段, 使 cwd 能与 workspace.path(存储时为 realpath 规范化值)
+ * 精确比对——这是官方 attachSession 强校验通过的前提。目录不存在时回退 resolve 结果, 由调用方告警不阻断。
+ */
+async function canonicalCwd(raw: string): Promise<string> {
+  try {
+    return await realpath(raw)
+  } catch {
+    return resolve(raw)
+  }
+}
+
+/** 官方 session.create RPC 同款姿势: resolveByPath ?? create, 幂等; 无 workspaceRegistry 时返回 undefined */
+async function ensureWorkspace(ctx: Context, canonical: string): Promise<WorkspaceView | undefined> {
+  const registry = ctx.get('workspaceRegistry') as WorkspaceRegistryView | undefined
+  if (!registry) return undefined
+  return (await registry.resolveByPath?.(canonical)) ?? (await registry.create?.(canonical))
+}
+
+/** 把会话挂名到其 cwd 对应的工作区。attachSession 内部强校验 realpath(header.cwd) 精确等于 workspace.path,
+ *  所以 canonical 必须是 header.cwd 的 realpath 规范化值。失败告警不阻断任务(分组是锦上添花)。 */
+async function attachToWorkspace(ctx: Context, canonical: string, sessionId: SessionId): Promise<void> {
+  try {
+    const ws = await ensureWorkspace(ctx, canonical)
+    if (ws?.attachSession) await ws.attachSession(sessionId)
+  } catch (e) {
+    console.warn('[harness-mcp-server] workspace attach failed:', (e as Error)?.message ?? e)
+  }
+}
+
+/** 按会话 header 的 cwd(realpath 规范化后)补挂工作区; header 无 cwd 时静默跳过 */
+async function attachSessionCwd(ctx: Context, sessionId: SessionId, cwd: string | undefined): Promise<void> {
+  if (cwd === undefined) return
+  await attachToWorkspace(ctx, await canonicalCwd(cwd), sessionId)
+}
+
 /** 常驻 agent 会话(按 cwd 复用, 省 token: 避免每次全量加载项目上下文) */
 const liveAgents = new Map<string, { sessionId: SessionId; handle: AgentHandle }>()
 
@@ -85,10 +147,19 @@ const sessionToCwd = new Map<string, string>()
 /** 每个 cwd 的串行执行锁(防同一 agent 会话被并发 followup 冲突) */
 const agentLocks = new Map<string, Promise<unknown>>()
 
-/** 获取(或创建)指定 cwd 的常驻 agent 会话; 传 sessionId 时续接指定会话; 传 title 时给新会话命名 */
-async function getAgent(ctx: Context, cwd: string, sessionId?: string, title?: string): Promise<{ sessionId: SessionId; handle: AgentHandle }> {
-  // 指定 sessionId: 续接已有会话(长任务分多轮投喂 / 中断后恢复)
+/** getAgent 的返回: handle 恒有 .agent; resume 出来的独占句柄带 disposeAfter 标记, 任务结束后应 flush+dispose */
+interface ResolvedAgent {
+  sessionId: SessionId
+  handle: AgentHandle
+  /** true = 本插件 resume 出来的独占句柄; false/缺省 = 常驻池会话或 live 接管(生命周期归池/owner) */
+  disposeAfter?: boolean
+}
+
+/** 获取(或创建)指定 cwd 的常驻 agent 会话; 传 sessionId 时接管指定会话; 传 title 时给新会话命名 */
+async function getAgent(ctx: Context, cwd: string, sessionId?: string, title?: string): Promise<ResolvedAgent> {
+  // 指定 sessionId: 接管已有会话(长任务分多轮投喂 / 中断后恢复 / UI 手开的会话)
   if (sessionId) {
+    // 先看本进程常驻池(指定 sessionId 时定位到对应 cwd 的常驻会话; 命中 LRU 移到末尾, 保留上游语义)
     const targetCwd = sessionToCwd.get(sessionId)
     if (targetCwd !== undefined) {
       const existing = liveAgents.get(targetCwd)
@@ -98,14 +169,48 @@ async function getAgent(ctx: Context, cwd: string, sessionId?: string, title?: s
         return existing
       }
     }
-    // 会话不在常驻表里(LRU 已淘汰或进程重启), 无法续接
-    throw new Error(`session not found for resume: ${sessionId} (evicted by LRU or process restarted)`)
+    const sid = SessionId(sessionId)
+    // 不在常驻池: 看 live(UI 手开的、别的插件持有的会话), 直接接管、不持有 dispose(归其 owner)
+    const live = ctx.agents.get(sid)
+    if (live) {
+      // live 会话也补挂工作区(幂等): 用户手开的会话若尚未归组, 这里一并挂名
+      await attachSessionCwd(ctx, sid, live.session.header.cwd)
+      // no-op dispose 兜底: executeTask 只在 disposeAfter 为 true 时调用 dispose
+      return { sessionId: sid, handle: { agent: live, dispose: () => Promise.resolve() }, disposeAfter: false }
+    }
+    // live 也没有: 从持久化会话存储 resume 并接管(进程重启前的会话、LRU 淘汰后被释放的会话)
+    let handle: AgentHandle
+    try {
+      handle = await ctx.agents.resume({
+        resumeSessionId: sid,
+        agentOptions: {
+          provider: runtimeConfig.provider,
+          // model 为空则省略, 让 dsh 跟随用户/默认设置; 显式配置则覆盖
+          ...(runtimeConfig.model ? { model: runtimeConfig.model } : {}),
+        },
+        setup: async (agentCtx) => {
+          // 同 create 路径: dsh rc.6 agent ctx 可能丢 scope tag, 检测不到就跳过挂载(降级为无工具 agent)
+          if (scopeOf(agentCtx) === undefined) {
+            console.warn('[harness-mcp-server] agent ctx unscoped (dsh rc.6 bug); preset mount skipped — upgrade dsh for full tool support')
+            return
+          }
+          await ctx.agentPresets.mount(agentCtx, runtimeConfig.preset)
+        },
+      })
+    } catch (e) {
+      // 恢复失败返回明确错误(沿用上游错误风格): 不在常驻池、不是 live、持久化里也没有(或 resume 失败)
+      throw new Error(`session not found for resume: ${sessionId} (not live and not persisted; ${(e as Error)?.message ?? e})`)
+    }
+    await attachSessionCwd(ctx, sid, handle.agent.session.header.cwd)
+    return { sessionId: sid, handle, disposeAfter: true }
   }
   const existing = liveAgents.get(cwd)
   if (existing) {
     // LRU: 命中则移到末尾(最近使用)
     liveAgents.delete(cwd)
     liveAgents.set(cwd, existing)
+    // 自愈: 幂等补挂(已在花名册则 no-op; 首次挂名失败的池会话在此被捞回)
+    await attachToWorkspace(ctx, await canonicalCwd(cwd), existing.sessionId)
     return existing
   }
   // LRU 淘汰: 超过上限时逐出最久未用的会话
@@ -120,10 +225,13 @@ async function getAgent(ctx: Context, cwd: string, sessionId?: string, title?: s
     }
   }
   const newSessionId = SessionId(randomUUID())
+  // cwd 先 realpath 规范化: session header 的 cwd 与 workspace.path 必须精确相等,
+  // 否则 attachSession 强校验 reject(只会 create 注册而 UI 仍落未分组)
+  const canonical = await canonicalCwd(cwd)
   const handle = await ctx.agents.create({
     sessionId: newSessionId,
     // 声明 preset: 为未来 Harness 版本消费 meta.agentPreset 做准备; 当前版本靠 setup 里手动 mount 兜底。
-    meta: { cwd, agentPreset: runtimeConfig.preset },
+    meta: { cwd: canonical, agentPreset: runtimeConfig.preset },
     agentOptions: {
       provider: runtimeConfig.provider,
       // model 为空则省略, 让 dsh 跟随用户/默认设置; 显式配置则覆盖
@@ -146,16 +254,11 @@ async function getAgent(ctx: Context, cwd: string, sessionId?: string, title?: s
   liveAgents.set(cwd, rec)
   sessionToCwd.set(String(newSessionId), cwd)
 
-  // 诉求3: 把会话归属到 cwd 对应的工作区分组(可选依赖; headless/无 workspaceRegistry 的环境自动跳过)
+  // 分组: 把会话归属到 cwd 对应的工作区(resolveByPath ?? create + attachSession; 可选依赖; headless 环境自动跳过)
   void (async () => {
     try {
-      const registry = ctx.get('workspaceRegistry') as
-        | { create?: (path: string) => Promise<{ attachSession?: (sid: SessionId) => Promise<void> }> }
-        | undefined
-      if (registry?.create) {
-        const workspace = await registry.create(cwd)
-        await workspace.attachSession?.(newSessionId)
-      }
+      const ws = await ensureWorkspace(ctx, canonical)
+      if (ws?.attachSession) await ws.attachSession(newSessionId)
     } catch (e) {
       console.warn('[harness-mcp-server] workspace attach failed:', String(e))
     }
@@ -236,8 +339,9 @@ function truncateResult(result: TaskResult): TaskResult {
 
 /** 核心执行: 组装任务(注入记忆上下文+结构化要求) → agent 执行 → 读结构化结果 */
 async function executeTask(ctx: Context, task: string, context: string, cwd: string, resumeSessionId?: string, title?: string): Promise<TaskResult> {
-  // 规范化 cwd, 避免 /a、/a/.、相对路径、符号链接成为不同 Map key 导致重复创建会话/并发冲突
-  const workdir = cwd ? resolve(cwd) : process.cwd()
+  // 规范化 cwd: realpath 解析符号链接与 .. 段, 避免 /a、/a/.、相对路径、符号链接成为不同 Map key
+  // 导致重复创建会话/并发冲突; 同时也是与 workspace.path 精确比对的唯一 canon
+  const workdir = await canonicalCwd(cwd ? resolve(cwd) : process.cwd())
   // cwd 白名单: 配置了 workspaceRoots 时, 只允许在列出的目录下干活(防路径穿越)
   if (runtimeConfig.workspaceRoots.length > 0) {
     const allowed = runtimeConfig.workspaceRoots.some((root) => {
@@ -248,8 +352,10 @@ async function executeTask(ctx: Context, task: string, context: string, cwd: str
       throw new Error(`cwd not allowed (outside workspaceRoots): ${workdir}`)
     }
   }
-  return withLock(workdir, async () => {
-    const { sessionId, handle } = await getAgent(ctx, workdir, resumeSessionId, title)
+  // sessionId 用 session 锁, 否则用 cwd 锁——都防同一 agent 会话被并发 followup
+  const lockKey = resumeSessionId ? `session:${resumeSessionId}` : workdir
+  return withLock(lockKey, async () => {
+    const { sessionId, handle, disposeAfter } = await getAgent(ctx, workdir, resumeSessionId, title)
     const baseline = ((handle.agent.session as unknown as { log?: unknown[] }).log ?? []).length
 
     // 组装完整任务文本: 记忆上下文 + 任务 + 结构化输出要求
@@ -315,6 +421,21 @@ async function executeTask(ctx: Context, task: string, context: string, cwd: str
     result.changes = summary.changes
     result.verification = summary.verification
     result.leftovers = summary.leftovers
+
+    // resume 兜底分支: 尽力 flush 持久化, 再释放我们 resume 出来的句柄(不留给僵尸 live agent)
+    if (disposeAfter) {
+      try {
+        await (ctx.get('sessions') as { flush?: (session: unknown) => Promise<unknown> } | undefined)?.flush?.(handle.agent.session)
+      } catch {
+        /* flush 失败不阻断结果返回 */
+      }
+      try {
+        await handle.dispose()
+      } catch {
+        /* 释放失败不影响结果 */
+      }
+    }
+
     return result
   })
 }
@@ -334,6 +455,58 @@ interface TaskItem {
   finishedAt?: number
 }
 const taskQueue = new Map<string, TaskItem>()
+
+/** 找会话 header: live 优先, 其次持久化 list(轻量元数据扫描, 不加载整日志) */
+async function findSessionHeader(ctx: Context, sessionId: SessionId): Promise<SessionHeader | undefined> {
+  const sessions = ctx.get('sessions') as { get?: (id: SessionId) => { header: SessionHeader } | undefined } | undefined
+  const live = sessions?.get?.(sessionId)
+  if (live !== undefined) return live.header
+  const persistence = ctx.get('sessionPersistence') as { list?: () => Promise<SessionHeader[]> } | undefined
+  for (const header of (await persistence?.list?.()) ?? []) {
+    if (header.id === sessionId) return header
+  }
+  return undefined
+}
+
+/**
+ * 存量捞回: 启动时把现存未分组的会话补挂到已注册工作区。
+ * 条件: header.cwd 的 realpath 等于某已注册 workspace.path, 且该 sessionId 不在其花名册里。
+ * 只补挂到"已注册"工作区, 不新建(避免把无关目录刷成新工作区); 单会话失败不影响其余。
+ */
+async function reattachOrphanSessions(ctx: Context): Promise<{ attached: number; failed: number }> {
+  const registry = ctx.get('workspaceRegistry') as WorkspaceRegistryView | undefined
+  const byPath = new Map<string, WorkspaceView>()
+  for (const ws of registry?.list?.() ?? []) byPath.set(ws.path, ws)
+  if (byPath.size === 0) return { attached: 0, failed: 0 }
+
+  // live + 持久化 header 合并(live 优先), 按 id 去重
+  const headers = new Map<string, SessionHeader>()
+  const sessions = ctx.get('sessions') as { list?: () => { header: SessionHeader }[] } | undefined
+  for (const session of sessions?.list?.() ?? []) headers.set(session.header.id, session.header)
+  const persistence = ctx.get('sessionPersistence') as { list?: () => Promise<SessionHeader[]> } | undefined
+  for (const header of (await persistence?.list?.()) ?? []) {
+    if (!headers.has(header.id)) headers.set(header.id, header)
+  }
+
+  let attached = 0
+  let failed = 0
+  for (const header of headers.values()) {
+    if (header.cwd === undefined) continue
+    const canonical = await canonicalCwd(header.cwd)
+    const ws = byPath.get(canonical)
+    if (ws === undefined || !ws.attachSession) continue
+    if (ws.sessionIds.includes(header.id)) continue
+    try {
+      await ws.attachSession(header.id)
+      attached++
+      console.log(`[harness-mcp-server] 存量捞回: session ${header.id} -> workspace ${ws.path}`)
+    } catch (e) {
+      failed++
+      console.warn(`[harness-mcp-server] 存量捞回失败 session ${header.id}:`, (e as Error)?.message ?? e)
+    }
+  }
+  return { attached, failed }
+}
 
 /** 在给定 McpServer 上注册工具 */
 function registerTools(mcp: McpServer, ctx: Context): void {
@@ -452,6 +625,39 @@ function registerTools(mcp: McpServer, ctx: Context): void {
       }
     },
   )
+
+  // 手动归组补给站: 官方 UI 没有"移动会话到工作区"功能, 本工具供随时归组
+  mcp.tool(
+    'attach_session',
+    '把会话归组到工作区(补给站: 官方 UI 无移动会话功能)。path 缺省用该会话 header 的 cwd; 归组依赖官方 attachSession 的强校验——realpath(header.cwd) 必须与工作区路径精确相等, 不匹配会返回官方报错。',
+    {
+      sessionId: z.string().describe('要归组的会话 id(live 或已持久化)'),
+      path: z.string().optional().describe('目标工作区目录(缺省: 会话 header 的 cwd)'),
+    },
+    async ({ sessionId, path }) => {
+      const sid = SessionId(sessionId)
+      const header = await findSessionHeader(ctx, sid)
+      if (header === undefined) {
+        return out(JSON.stringify({ error: `session not found: ${sessionId}(live 与持久化里都没有)` }))
+      }
+      const target = path ?? header.cwd
+      if (target === undefined) {
+        return out(JSON.stringify({ error: `session ${sessionId} 的 header 没有 cwd, 官方 attachSession 无法校验, 不能归组` }))
+      }
+      try {
+        const canonical = await realpath(target) // 目标必须是存在的目录, 否则 ENOENT
+        const ws = await ensureWorkspace(ctx, canonical)
+        if (!ws?.attachSession) return out(JSON.stringify({ error: 'workspaceRegistry unavailable' }))
+        if (ws.sessionIds.includes(sid)) {
+          return out(JSON.stringify({ sessionId, workspaceId: ws.id, workspacePath: ws.path, attached: false, note: 'already attached' }))
+        }
+        await ws.attachSession(sid)
+        return out(JSON.stringify({ sessionId, workspaceId: ws.id, workspacePath: ws.path, attached: true }))
+      } catch (e) {
+        return out(JSON.stringify({ error: `attach failed: ${(e as Error)?.message ?? String(e)}` }))
+      }
+    },
+  )
 }
 
 /**
@@ -542,6 +748,16 @@ export async function apply(ctx: Context, config: Config = {}): Promise<void> {
   server.on('error', (e) => {
     console.error('[harness-mcp-server] HTTP server error:', e.message)
   })
+
+  // 存量捞回: 启动后异步补挂未分组会话, 不阻塞启动; 全程兜底 try/catch 防 unhandled rejection
+  void (async () => {
+    try {
+      const r = await reattachOrphanSessions(ctx)
+      console.log(`[harness-mcp-server] 存量捞回完成: attached=${r.attached} failed=${r.failed}`)
+    } catch (e) {
+      console.warn('[harness-mcp-server] 存量捞回异常:', (e as Error)?.message ?? e)
+    }
+  })()
 
   // 标准 cordis 生命周期: 用 ctx.effect 注册清理(卸载时关 server + 清空全部映射/会话/队列)
   ctx.effect(() => {


### PR DESCRIPTION
> 本 PR 的三块增量都在我们的 fork（内部版本 dsh-harness-mcp-plus）里长期实跑过；v0.1.9 收进 sessionId 续接/模型跟随/分组/title/rename 之后（issue #2 已讨论），我们 diff 了 v0.1.9 与 fork 的全部差异，确认还有**三块增量是 v0.1.9 没有的**，本次以 v0.1.9 为基线原样移植过来。

## 一、背景与动机

1. **任意会话续接**：v0.1.9 的 `sessionToCwd` 内存表只认「本进程桥建的会话」——LRU 淘汰后、进程重启前的会话、以及用户从 UI 手开的会话，`agent_run(sessionId=…)` 都会报 `session not found for resume`。增量改为三级接管：常驻池 → live 会话 → 持久化 resume，任意存在的会话都能续接。
2. **realpath 规范化**：官方 `attachSession` 内部强校验 `realpath(header.cwd) === workspace.path`。v0.1.9 直接用原始 cwd 建会话、挂工作区，凡是经过符号链接/`..` 的 cwd 都会挂组失败（会话建了、UI 仍落未分组）。增量把 cwd 先过 `fs.realpath` 再进 header 与 `workspaceRegistry.resolveByPath ?? create`。
3. **attach_session 工具 + 存量捞回**：官方 UI 没有「把会话移进工作区」的能力，历史会话一旦未分组就永远是孤儿。增量新增 `attach_session(sessionId[, path])` 工具，并在插件启动时把存量未分组会话补挂到已注册工作区（只补挂、不新建）。

**保持原样的**：LRU maxAgents、title/rename_session 实现、模型跟随逻辑、HTTP server 与错误风格——全部未动，以降低 review 阻力。

## 二、实现说明（对应 src/index.ts）

### 1. 任意会话续接（`getAgent` 的 sessionId 分支 + `executeTask`）

- 顺序：`sessionToCwd`/常驻池命中（保留你原来的 LRU 移尾语义）→ `ctx.agents.get(sessionId)` 命中 live 会话（UI 手开的、别的插件持有的）直接复用，**不持有 dispose**（生命周期归 owner）→ `ctx.agents.resume({ resumeSessionId })` 从持久化恢复。
- resume 出来的句柄带 `disposeAfter` 标记：任务结束后先 `sessions.flush` 尽力落盘、再 `dispose`，不留僵尸 live agent；池会话与 live 接管不释放。
- resume 失败（live 没有 + 持久化没有，或恢复本身失败）沿用你原来的报错风格：
  `session not found for resume: <id> (not live and not persisted; <原因>)`
- 并发锁：传 sessionId 时用 `session:<id>` 锁，否则用 cwd 锁（沿用 `withLock` 串行语义，防同一会话被并发 followup）。
- 新增依赖声明：`inject` 补 `sessions` / `sessionPersistence` / `workspaceRegistry`。**这三个名字必须在 inject 里**——我们 fork 早先在真实启动时踩过坑：服务只靠 `ctx.get` 用、没进 inject 清单，启动时拿不到服务。

### 2. realpath 规范化（`canonicalCwd` / `ensureWorkspace` / `attachToWorkspace`）

- `canonicalCwd(raw)`：`fs.realpath` 成功用结果，目录不存在回退 `resolve(raw)`（告警不阻断任务）。
- `executeTask` 入口先 canonical，create 的 `meta.cwd` 用 canonical 值；工作区挂名改为官方 session.create RPC 同款姿势 `resolveByPath(canonical) ?? create(canonical)` 再 `attachSession`。
- 池命中时加了一次幂等自愈补挂（首次挂名失败的池会话被捞回；已在花名册则 no-op）。
- 挂名失败一律 `console.warn` 不阻断任务——分组是元数据，不废任务本身。沿用你原来的 fire-and-forget 结构，只是内部换成上述 helper。

### 3. attach_session 工具 + 存量捞回（`findSessionHeader` / `reattachOrphanSessions`）

- `attach_session(sessionId, path?)`：live 优先、持久化 `sessionPersistence.list()` 兜底找 header；path 缺省用 header.cwd；目标目录必须存在（`fs.realpath`，否则 ENOENT 如实报错）；已在花名册返回 `attached: false`，否则 `ws.attachSession` 后返回 `attached: true`。headless/无 workspaceRegistry 的环境返回明确 unavailable 错误。
- 启动捞回：`apply()` 末尾异步执行，不阻塞启动；把 live 列表 + 持久化列表的 header 按 id 去重，`header.cwd` 的 realpath 命中某**已注册** workspace.path 且不在花名册的，补挂。只补挂到已注册工作区、不新建，避免把无关目录刷成新工作区；单会话失败不影响其余，全程 try/catch 防 unhandled rejection。

## 三、测试与验证

- **typecheck**：`strict: true` 下 tsc 零错误（本机用 rc.6 版 `@deepseek-ai/*` 类型）。
- **构建**：`lib/` 已按你的布局重新生成（`lib/index.js` + `lib/types/index.js` + `lib/types/index.d.ts`）。说明：本机没有你的 monorepo 构建环境（tsconfig 引用 `../../../vendor/*`），`lib/index.js` 是用 tsc 产出后**内联了 `scopeOf`** 生成的——和你的 tsdown bundle 同款处理。你合入前在 monorepo 里正常 `npm run build` 一次即可，产物会由 tsdown 重新打包。
- **冒烟**：仓库根附了开发用 `smoke.mjs`（不进 npm `files`，可留可删）：假 ctx + 本地 8099 HTTP 走 MCP 协议，13 项全 PASS，覆盖 live 接管 / resume+flush+dispose / 未知会话报错 / meta.cwd 为 realpath 值 / 目录不存在回退不阻断 / attach_session 三态 / 存量捞回双源（live 列表 + 持久化列表）。
- 上游仓库没有测试套件（package.json 无 test script），本次未引入测试。

## 四、遗留与备注

- 增量只动了上面三条路径；`rename_session`/title/模型跟随等你的实现一字未动。
- `smoke.mjs` 是开发验证脚本，npm 发布不含它；要不要留在仓库由你定。
- 我们 fork 侧计划：上游合入并验证后，我们逐步退掉本地 fork 的对应实现、改追你的主干版本。